### PR TITLE
[SECURITY RISK] Bump country language to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/runtime": "^7.1.2",
     "axios": "^0.21.1",
     "axios-retry": "^3.1.1",
-    "country-language": "^0.1.7",
+    "country-language": "^0.1.8",
     "pope": "^2.0.2",
     "lodash": "^4.17.13"
   }


### PR DESCRIPTION
Prior to 0.1.8, country-launguage had a dependency to a library named `underscore` and it had it to use version 1.7.0. However, from 1.3.2 and before 1.12.1 that library is vulnerable to RCE. See more about this here: https://www.npmjs.com/advisories/1674. 

Country-Language got updated to 0.1.8 to upgrade the underscore dependency to ^1.13.1, see details here. https://github.com/bdswiss/country-language/commit/caca2bbe4dfb4402b43958413717527b299392e1.