### PR TITLE
Update package readme and remove country-language dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2025.02.05
+## [2.0.0] - 2025.02.06
 ### Changed
 - Completely rewrites the core of the `CustomizrClient`
 - Moves from `axios` to `fetch` API to reduce dependencies
 - Updates dependencies to resolve security vulnerabilities
 - Adds Typescript for the `CustomizrClient`
+- Copies the necessary language data from `country-language` and removes the package to resolve a security vulnerability
 
 ## [1.2.0] - 2021.05.19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-[![npm version](https://badge.fury.io/js/cimpress-customizr.svg)](https://badge.fury.io/js/cimpress-customizr)
-[![Build Status](https://travis-ci.org/Cimpress/cimpress-customizr.svg?branch=master)](https://travis-ci.org/Cimpress/cimpress-customizr)
-
-# cimpress-customizr
+# @cimpress-technology/customizr
 A thin client for accessing Cimpress Customizr service
 
 ## Breaking Changes - 2.0.0 Release
@@ -12,13 +9,15 @@ This release also adds Typescript for the `CustomizrClient` and exports the type
 
 ## Usage
 
+For versions `2.x.x` and later, you'll need to configure the `cimpress-technology` scope and will need a Cimpress Artifactory token to download the package.
+
 Install the package:
     
-    npm install --save cimpress-customizr
+    npm install --save @cimpress-technology/customizr
 
 Using the client
     
-    import {CustomizrClient} from 'cimpress-customizr'
+    import {CustomizrClient} from '@cimpress-technology/customizr'
     
     const client = new CustomizrClient({
         // The resource you'd like to get/put the settings from/to.
@@ -81,7 +80,9 @@ You can also use directly any of the following convenience functions:
     
     setPreferredMcpLanguage(accessToken, newLanguage).then( ... )
 
-    
+### Versions before 2.x.x
+
+This package was [originally published in the npm registry](https://www.npmjs.com/package/cimpress-customizr) under the name `cimpress-customizr`. All versions up to `1.2.0` can be found there. We recommend using version `2.x.x` or later to get security updates and feature improvements.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-  "name": "cimpress-customizr",
+  "name": "@cimpress-technology/customizr",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cimpress-customizr",
+      "name": "@cimpress-technology/customizr",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.7",
-        "country-language": "^0.1.7",
         "lodash": "^4.17.13",
         "pope": "^2.0.2"
       },
@@ -5309,18 +5308,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/country-language": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/country-language/-/country-language-0.1.7.tgz",
-      "integrity": "sha512-QH8GvZehR0IsFSR8ZPzteaCq/JjsLKk+tHWSQciXVpredI/2Xaf1VAdCuo/XPFWSrRCkSLaZNqnOcot4zceAIw==",
-      "dependencies": {
-        "underscore": "~1.7.0",
-        "underscore.deep": "~0.5.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -9854,22 +9841,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA=="
-    },
-    "node_modules/underscore.deep": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/underscore.deep/-/underscore.deep-0.5.3.tgz",
-      "integrity": "sha512-4OuSOlFNkiVFVc3khkeG112Pdu1gbitMj7t9B9ENb61uFmN70Jq7Iluhi3oflcSgexkKfDdJ5XAJET2gEq6ikA==",
-      "engines": {
-        "node": ">=0.10.x"
-      },
-      "peerDependencies": {
-        "underscore": "1.x"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cimpress-customizr",
+  "name": "@cimpress-technology/customizr",
   "version": "2.0.0",
   "description": "A thin client for Cimpress Customizr service",
   "main": "./lib/index.js",
@@ -60,7 +60,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.7",
-    "country-language": "^0.1.7",
     "lodash": "^4.17.13",
     "pope": "^2.0.2"
   }

--- a/src/mcpHelpers.js
+++ b/src/mcpHelpers.js
@@ -1,5 +1,5 @@
 import CustomizrClient from './CustomizrClient';
-import { countryLanguage } from './utils';
+import {countryLanguage} from './utils';
 
 import {
     getValidLanguageOrThrow,

--- a/src/mcpHelpers.js
+++ b/src/mcpHelpers.js
@@ -1,5 +1,5 @@
 import CustomizrClient from './CustomizrClient';
-import countryLanguage from 'country-language';
+import { countryLanguage } from './utils';
 
 import {
     getValidLanguageOrThrow,
@@ -79,7 +79,7 @@ async function getPreferredMcpLanguages(accessToken, sessionId = undefined) {
     const twoLetterArray = mcpSettings.language || [];
 
     return twoLetterArray.map((twoLetter) => {
-        let language = countryLanguage.getLanguages().find((a) => a.iso639_1 === twoLetter);
+        let language = countryLanguage.find((a) => a.iso639_1 === twoLetter);
         return {
             lang: twoLetter,
             iso639_1: language ? language.iso639_1 : twoLetter,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8391 @@
-import countryLanguage from 'country-language';
 import validTimezones from './validTimezones';
 
+export const countryLanguage = [
+    {
+      "iso639_1": "ab",
+      "iso639_2": "abk",
+      "iso639_2en": "abk",
+      "iso639_3": "abk",
+      "name": [
+        "Abkhaz"
+      ],
+      "nativeName": [
+        "аҧсуа бызшәа",
+        "аҧсшәа"
+      ],
+      "direction": "LTR",
+      "family": "Northwest Caucasian"
+    },
+    {
+      "iso639_1": "aa",
+      "iso639_2": "aar",
+      "iso639_2en": "aar",
+      "iso639_3": "aar",
+      "name": [
+        "Afar"
+      ],
+      "nativeName": [
+        "Afaraf"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "DJI"
+      ]
+    },
+    {
+      "iso639_1": "af",
+      "iso639_2": "afr",
+      "iso639_2en": "afr",
+      "iso639_3": "afr",
+      "name": [
+        "Afrikaans"
+      ],
+      "nativeName": [
+        "Afrikaans"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ZAF"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "af-ZA",
+          "displayName": "Afrikaans - South Africa",
+          "cultureCode": "0x0436"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ak",
+      "iso639_2": "aka",
+      "iso639_2en": "aka",
+      "iso639_3": "aka",
+      "name": [
+        "Akan"
+      ],
+      "nativeName": [
+        "Akan"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "GHA"
+      ]
+    },
+    {
+      "iso639_1": "sq",
+      "iso639_2": "sqi",
+      "iso639_2en": "alb",
+      "iso639_3": "sqi",
+      "name": [
+        "Albanian"
+      ],
+      "nativeName": [
+        "gjuha shqipe"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ALB"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "sq-AL",
+          "displayName": "Albanian - Albania",
+          "cultureCode": "0x041C"
+        }
+      ]
+    },
+    {
+      "iso639_1": "am",
+      "iso639_2": "amh",
+      "iso639_2en": "amh",
+      "iso639_3": "amh",
+      "name": [
+        "Amharic"
+      ],
+      "nativeName": [
+        "አማርኛ"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "ETH"
+      ]
+    },
+    {
+      "iso639_1": "ar",
+      "iso639_2": "ara",
+      "iso639_2en": "ara",
+      "iso639_3": "ara",
+      "name": [
+        "Arabic"
+      ],
+      "nativeName": [
+        "العربية"
+      ],
+      "direction": "RTL",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "DZA",
+        "BHR",
+        "TCD",
+        "COM",
+        "DJI",
+        "EGY",
+        "ERI",
+        "IRQ",
+        "ISR",
+        "JOR",
+        "KWT",
+        "LBN",
+        "LBY",
+        "MRT",
+        "MAR",
+        "NER",
+        "OMN",
+        "QAT",
+        "SAU",
+        "SOM",
+        "SDN",
+        "SYR",
+        "TUN",
+        "ARE",
+        "YEM"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ar-DZ",
+          "displayName": "Arabic - Algeria",
+          "cultureCode": "0x1401"
+        },
+        {
+          "langCultureName": "ar-BH",
+          "displayName": "Arabic - Bahrain",
+          "cultureCode": "0x3C01"
+        },
+        {
+          "langCultureName": "ar-EG",
+          "displayName": "Arabic - Egypt",
+          "cultureCode": "0x0C01"
+        },
+        {
+          "langCultureName": "ar-IQ",
+          "displayName": "Arabic - Iraq",
+          "cultureCode": "0x0801"
+        },
+        {
+          "langCultureName": "ar-JO",
+          "displayName": "Arabic - Jordan",
+          "cultureCode": "0x2C01"
+        },
+        {
+          "langCultureName": "ar-KW",
+          "displayName": "Arabic - Kuwait",
+          "cultureCode": "0x3401"
+        },
+        {
+          "langCultureName": "ar-LB",
+          "displayName": "Arabic - Lebanon",
+          "cultureCode": "0x3001"
+        },
+        {
+          "langCultureName": "ar-LY",
+          "displayName": "Arabic - Libya",
+          "cultureCode": "0x1001"
+        },
+        {
+          "langCultureName": "ar-MA",
+          "displayName": "Arabic - Morocco",
+          "cultureCode": "0x1801"
+        },
+        {
+          "langCultureName": "ar-OM",
+          "displayName": "Arabic - Oman",
+          "cultureCode": "0x2001"
+        },
+        {
+          "langCultureName": "ar-QA",
+          "displayName": "Arabic - Qatar",
+          "cultureCode": "0x4001"
+        },
+        {
+          "langCultureName": "ar-SA",
+          "displayName": "Arabic - Saudi Arabia",
+          "cultureCode": "0x0401"
+        },
+        {
+          "langCultureName": "ar-SY",
+          "displayName": "Arabic - Syria",
+          "cultureCode": "0x2801"
+        },
+        {
+          "langCultureName": "ar-TN",
+          "displayName": "Arabic - Tunisia",
+          "cultureCode": "0x1C01"
+        },
+        {
+          "langCultureName": "ar-AE",
+          "displayName": "Arabic - United Arab Emirates",
+          "cultureCode": "0x3801"
+        },
+        {
+          "langCultureName": "ar-YE",
+          "displayName": "Arabic - Yemen",
+          "cultureCode": "0x2401"
+        }
+      ]
+    },
+    {
+      "iso639_1": "an",
+      "iso639_2": "arg",
+      "iso639_2en": "arg",
+      "iso639_3": "arg",
+      "name": [
+        "Aragonese"
+      ],
+      "nativeName": [
+        "aragonés"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "hy",
+      "iso639_2": "hye",
+      "iso639_2en": "arm",
+      "iso639_3": "hye",
+      "name": [
+        "Armenian"
+      ],
+      "nativeName": [
+        "Հայերեն"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ARM"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "hy-AM",
+          "displayName": "Armenian - Armenia",
+          "cultureCode": "0x042B"
+        }
+      ]
+    },
+    {
+      "iso639_1": "as",
+      "iso639_2": "asm",
+      "iso639_2en": "asm",
+      "iso639_3": "asm",
+      "name": [
+        "Assamese"
+      ],
+      "nativeName": [
+        "অসমীয়া"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "av",
+      "iso639_2": "ava",
+      "iso639_2en": "ava",
+      "iso639_3": "ava",
+      "name": [
+        "Avaric"
+      ],
+      "nativeName": [
+        "авар мацӀ",
+        "магӀарул мацӀ"
+      ],
+      "direction": "LTR",
+      "family": "Northeast Caucasian"
+    },
+    {
+      "iso639_1": "ae",
+      "iso639_2": "ave",
+      "iso639_2en": "ave",
+      "iso639_3": "ave",
+      "name": [
+        "Avestan"
+      ],
+      "nativeName": [
+        "avesta"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "ay",
+      "iso639_2": "aym",
+      "iso639_2en": "aym",
+      "iso639_3": "aym",
+      "name": [
+        "Aymara"
+      ],
+      "nativeName": [
+        "aymar aru"
+      ],
+      "direction": "LTR",
+      "family": "Aymaran",
+      "countries": [
+        "BOL",
+        "PER"
+      ]
+    },
+    {
+      "iso639_1": "az",
+      "iso639_2": "aze",
+      "iso639_2en": "aze",
+      "iso639_3": "aze",
+      "name": [
+        "Azerbaijani"
+      ],
+      "nativeName": [
+        "azərbaycan dili"
+      ],
+      "direction": "LTR",
+      "family": "Turkic",
+      "countries": [
+        "AZE"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "Cy-az-AZ",
+          "displayName": "Azeri (Cyrillic) - Azerbaijan",
+          "cultureCode": "0x082C"
+        },
+        {
+          "langCultureName": "Lt-az-AZ",
+          "displayName": "Azeri (Latin) - Azerbaijan",
+          "cultureCode": "0x042C"
+        }
+      ]
+    },
+    {
+      "iso639_1": "bm",
+      "iso639_2": "bam",
+      "iso639_2en": "bam",
+      "iso639_3": "bam",
+      "name": [
+        "Bambara"
+      ],
+      "nativeName": [
+        "bamanankan"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "MLI"
+      ]
+    },
+    {
+      "iso639_1": "ba",
+      "iso639_2": "bak",
+      "iso639_2en": "bak",
+      "iso639_3": "bak",
+      "name": [
+        "Bashkir"
+      ],
+      "nativeName": [
+        "башҡорт теле"
+      ],
+      "direction": "LTR",
+      "family": "Turkic"
+    },
+    {
+      "iso639_1": "eu",
+      "iso639_2": "eus",
+      "iso639_2en": "baq",
+      "iso639_3": "eus",
+      "name": [
+        "Basque"
+      ],
+      "nativeName": [
+        "euskara",
+        "euskera"
+      ],
+      "direction": "LTR",
+      "family": "Language isolate",
+      "langCultureMs": [
+        {
+          "langCultureName": "eu-ES",
+          "displayName": "Basque - Basque",
+          "cultureCode": "0x042D"
+        }
+      ]
+    },
+    {
+      "iso639_1": "be",
+      "iso639_2": "bel",
+      "iso639_2en": "bel",
+      "iso639_3": "bel",
+      "name": [
+        "Belarusian"
+      ],
+      "nativeName": [
+        "беларуская мова"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "BLR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "be-BY",
+          "displayName": "Belarusian - Belarus",
+          "cultureCode": "0x0423"
+        }
+      ]
+    },
+    {
+      "iso639_1": "bn",
+      "iso639_2": "ben",
+      "iso639_2en": "ben",
+      "iso639_3": "ben",
+      "name": [
+        "Bengali",
+        "Bangla"
+      ],
+      "nativeName": [
+        "বাংলা"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "BGD",
+        "IND"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ber",
+      "iso639_2en": "ber",
+      "iso639_3": "ber",
+      "name": [
+        "Berber"
+      ],
+      "nativeName": [
+        "Tamaziɣt",
+        "Tamazight",
+        "ⵜⴰⵎⴰⵣⵉⵖⵜ"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "DZA",
+        "MAR"
+      ]
+    },
+    {
+      "iso639_1": "bh",
+      "iso639_2": "bih",
+      "iso639_2en": "bih",
+      "iso639_3": "",
+      "name": [
+        "Bihari"
+      ],
+      "nativeName": [
+        "भोजपुरी"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "bi",
+      "iso639_2": "bis",
+      "iso639_2en": "bis",
+      "iso639_3": "bis",
+      "name": [
+        "Bislama"
+      ],
+      "nativeName": [
+        "Bislama"
+      ],
+      "direction": "LTR",
+      "family": "Creole",
+      "countries": [
+        "VUT"
+      ]
+    },
+    {
+      "iso639_1": "bs",
+      "iso639_2": "bos",
+      "iso639_2en": "bos",
+      "iso639_3": "bos",
+      "name": [
+        "Bosnian"
+      ],
+      "nativeName": [
+        "bosanski jezik"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "BIH"
+      ]
+    },
+    {
+      "iso639_1": "br",
+      "iso639_2": "bre",
+      "iso639_2en": "bre",
+      "iso639_3": "bre",
+      "name": [
+        "Breton"
+      ],
+      "nativeName": [
+        "brezhoneg"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "bg",
+      "iso639_2": "bul",
+      "iso639_2en": "bul",
+      "iso639_3": "bul",
+      "name": [
+        "Bulgarian"
+      ],
+      "nativeName": [
+        "български език"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "BGR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "bg-BG",
+          "displayName": "Bulgarian - Bulgaria",
+          "cultureCode": "0x0402"
+        }
+      ]
+    },
+    {
+      "iso639_1": "my",
+      "iso639_2": "mya",
+      "iso639_2en": "bur",
+      "iso639_3": "mya",
+      "name": [
+        "Burmese"
+      ],
+      "nativeName": [
+        "ဗမာစာ"
+      ],
+      "direction": "LTR",
+      "family": "Sino-Tibetan",
+      "countries": [
+        "MMR"
+      ]
+    },
+    {
+      "iso639_1": "ca",
+      "iso639_2": "cat",
+      "iso639_2en": "cat",
+      "iso639_3": "cat",
+      "name": [
+        "Catalan",
+        "Valencian"
+      ],
+      "nativeName": [
+        "català",
+        "valencià"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "AND"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ca-ES",
+          "displayName": "Catalan - Catalan",
+          "cultureCode": "0x0403"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ch",
+      "iso639_2": "cha",
+      "iso639_2en": "cha",
+      "iso639_3": "cha",
+      "name": [
+        "Chamorro"
+      ],
+      "nativeName": [
+        "Chamoru"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian"
+    },
+    {
+      "iso639_1": "ce",
+      "iso639_2": "che",
+      "iso639_2en": "che",
+      "iso639_3": "che",
+      "name": [
+        "Chechen"
+      ],
+      "nativeName": [
+        "нохчийн мотт"
+      ],
+      "direction": "LTR",
+      "family": "Northeast Caucasian"
+    },
+    {
+      "iso639_1": "ny",
+      "iso639_2": "nya",
+      "iso639_2en": "nya",
+      "iso639_3": "nya",
+      "name": [
+        "Chichewa",
+        "Chewa",
+        "Nyanja"
+      ],
+      "nativeName": [
+        "chiCheŵa",
+        "chinyanja"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "MWI"
+      ]
+    },
+    {
+      "iso639_1": "zh",
+      "iso639_2": "zho",
+      "iso639_2en": "chi",
+      "iso639_3": "zho",
+      "name": [
+        "Chinese"
+      ],
+      "nativeName": [
+        "中文 (Zhōngwén)",
+        "汉语",
+        "漢語"
+      ],
+      "direction": "LTR",
+      "family": "Sino-Tibetan",
+      "countries": [
+        "HKG",
+        "MAC",
+        "CHN",
+        "TWN",
+        "SGP"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "zh-CN",
+          "displayName": "Chinese - China",
+          "cultureCode": "0x0804"
+        },
+        {
+          "langCultureName": "zh-HK",
+          "displayName": "Chinese - Hong Kong SAR",
+          "cultureCode": "0x0C04"
+        },
+        {
+          "langCultureName": "zh-MO",
+          "displayName": "Chinese - Macau SAR",
+          "cultureCode": "0x1404"
+        },
+        {
+          "langCultureName": "zh-SG",
+          "displayName": "Chinese - Singapore",
+          "cultureCode": "0x1004"
+        },
+        {
+          "langCultureName": "zh-TW",
+          "displayName": "Chinese - Taiwan",
+          "cultureCode": "0x0404"
+        },
+        {
+          "langCultureName": "zh-CHS",
+          "displayName": "Chinese (Simplified)",
+          "cultureCode": "0x0004"
+        },
+        {
+          "langCultureName": "zh-CHT",
+          "displayName": "Chinese (Traditional)",
+          "cultureCode": "0x7C04"
+        }
+      ]
+    },
+    {
+      "iso639_1": "cv",
+      "iso639_2": "chv",
+      "iso639_2en": "chv",
+      "iso639_3": "chv",
+      "name": [
+        "Chuvash"
+      ],
+      "nativeName": [
+        "чӑваш чӗлхи"
+      ],
+      "direction": "LTR",
+      "family": "Turkic"
+    },
+    {
+      "iso639_1": "kw",
+      "iso639_2": "cor",
+      "iso639_2en": "cor",
+      "iso639_3": "cor",
+      "name": [
+        "Cornish"
+      ],
+      "nativeName": [
+        "Kernewek"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "co",
+      "iso639_2": "cos",
+      "iso639_2en": "cos",
+      "iso639_3": "cos",
+      "name": [
+        "Corsican"
+      ],
+      "nativeName": [
+        "corsu",
+        "lingua corsa"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "cr",
+      "iso639_2": "cre",
+      "iso639_2en": "cre",
+      "iso639_3": "cre",
+      "name": [
+        "Cree"
+      ],
+      "nativeName": [
+        "ᓀᐦᐃᔭᐍᐏᐣ"
+      ],
+      "direction": "LTR",
+      "family": "Algonquian"
+    },
+    {
+      "iso639_1": "hr",
+      "iso639_2": "hrv",
+      "iso639_2en": "hrv",
+      "iso639_3": "hrv",
+      "name": [
+        "Croatian"
+      ],
+      "nativeName": [
+        "hrvatski jezik"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "HRV",
+        "BIH"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "hr-HR",
+          "displayName": "Croatian - Croatia",
+          "cultureCode": "0x041A"
+        }
+      ]
+    },
+    {
+      "iso639_1": "cs",
+      "iso639_2": "ces",
+      "iso639_2en": "cze",
+      "iso639_3": "ces",
+      "name": [
+        "Czech"
+      ],
+      "nativeName": [
+        "čeština",
+        "český jazyk"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "CZE",
+        "SVK"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "cs-CZ",
+          "displayName": "Czech - Czech Republic",
+          "cultureCode": "0x0405"
+        }
+      ]
+    },
+    {
+      "iso639_1": "da",
+      "iso639_2": "dan",
+      "iso639_2en": "dan",
+      "iso639_3": "dan",
+      "name": [
+        "Danish"
+      ],
+      "nativeName": [
+        "dansk"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "DNK",
+        "FRO"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "da-DK",
+          "displayName": "Danish - Denmark",
+          "cultureCode": "0x0406"
+        }
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "",
+      "iso639_2en": "",
+      "iso639_3": "prs",
+      "name": [
+        "Dari"
+      ],
+      "nativeName": [
+        "فارسی دری"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "AFG"
+      ]
+    },
+    {
+      "iso639_1": "dv",
+      "iso639_2": "div",
+      "iso639_2en": "div",
+      "iso639_3": "div",
+      "name": [
+        "Divehi",
+        "Dhivehi",
+        "Maldivian"
+      ],
+      "nativeName": [
+        "ދިވެހި"
+      ],
+      "direction": "RTL",
+      "family": "Indo-European",
+      "countries": [
+        "MDV"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "div-MV",
+          "displayName": "Dhivehi - Maldives",
+          "cultureCode": "0x0465"
+        }
+      ]
+    },
+    {
+      "iso639_1": "nl",
+      "iso639_2": "nld",
+      "iso639_2en": "dut",
+      "iso639_3": "nld",
+      "name": [
+        "Dutch"
+      ],
+      "nativeName": [
+        "Nederlands",
+        "Vlaams"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "BEL",
+        "NLD",
+        "ABW",
+        "CUW",
+        "SXM",
+        "SUR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "nl-BE",
+          "displayName": "Dutch - Belgium",
+          "cultureCode": "0x0813"
+        },
+        {
+          "langCultureName": "nl-NL",
+          "displayName": "Dutch - The Netherlands",
+          "cultureCode": "0x0413"
+        }
+      ]
+    },
+    {
+      "iso639_1": "dz",
+      "iso639_2": "dzo",
+      "iso639_2en": "dzo",
+      "iso639_3": "dzo",
+      "name": [
+        "Dzongkha"
+      ],
+      "nativeName": [
+        "རྫོང་ཁ"
+      ],
+      "direction": "LTR",
+      "family": "Sino-Tibetan",
+      "countries": [
+        "BTN"
+      ]
+    },
+    {
+      "iso639_1": "en",
+      "iso639_2": "eng",
+      "iso639_2en": "eng",
+      "iso639_3": "eng",
+      "name": [
+        "English"
+      ],
+      "nativeName": [
+        "English"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ATG",
+        "AUS",
+        "BHS",
+        "BRB",
+        "BLZ",
+        "BWA",
+        "CMR",
+        "CAN",
+        "CUW",
+        "DMA",
+        "ERI",
+        "FJI",
+        "GMB",
+        "GHA",
+        "GRD",
+        "GUY",
+        "HKG",
+        "IND",
+        "IRL",
+        "JAM",
+        "KEN",
+        "KIR",
+        "LSO",
+        "LBR",
+        "MWI",
+        "MYS",
+        "MLT",
+        "MHL",
+        "MUS",
+        "FSM",
+        "NAM",
+        "NRU",
+        "NZL",
+        "NGA",
+        "PAK",
+        "PLW",
+        "PNG",
+        "PHL",
+        "RWA",
+        "KNA",
+        "LCA",
+        "VCT",
+        "WSM",
+        "SYC",
+        "SLE",
+        "SGP",
+        "SXM",
+        "SLB",
+        "ZAF",
+        "SSD",
+        "LKA",
+        "SDN",
+        "SWZ",
+        "TZA",
+        "TON",
+        "TTO",
+        "TUV",
+        "UGA",
+        "GBR",
+        "USA",
+        "VUT",
+        "ZMB",
+        "ZWE"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "en-AU",
+          "displayName": "English - Australia",
+          "cultureCode": "0x0C09"
+        },
+        {
+          "langCultureName": "en-BZ",
+          "displayName": "English - Belize",
+          "cultureCode": "0x2809"
+        },
+        {
+          "langCultureName": "en-CA",
+          "displayName": "English - Canada",
+          "cultureCode": "0x1009"
+        },
+        {
+          "langCultureName": "en-CB",
+          "displayName": "English - Caribbean",
+          "cultureCode": "0x2409"
+        },
+        {
+          "langCultureName": "en-IE",
+          "displayName": "English - Ireland",
+          "cultureCode": "0x1809"
+        },
+        {
+          "langCultureName": "en-JM",
+          "displayName": "English - Jamaica",
+          "cultureCode": "0x2009"
+        },
+        {
+          "langCultureName": "en-NZ",
+          "displayName": "English - New Zealand",
+          "cultureCode": "0x1409"
+        },
+        {
+          "langCultureName": "en-PH",
+          "displayName": "English - Philippines",
+          "cultureCode": "0x3409"
+        },
+        {
+          "langCultureName": "en-ZA",
+          "displayName": "English - South Africa",
+          "cultureCode": "0x1C09"
+        },
+        {
+          "langCultureName": "en-TT",
+          "displayName": "English - Trinidad and Tobago",
+          "cultureCode": "0x2C09"
+        },
+        {
+          "langCultureName": "en-GB",
+          "displayName": "English - United Kingdom",
+          "cultureCode": "0x0809"
+        },
+        {
+          "langCultureName": "en-US",
+          "displayName": "English - United States",
+          "cultureCode": "0x0409"
+        },
+        {
+          "langCultureName": "en-ZW",
+          "displayName": "English - Zimbabwe",
+          "cultureCode": "0x3009"
+        }
+      ]
+    },
+    {
+      "iso639_1": "eo",
+      "iso639_2": "epo",
+      "iso639_2en": "epo",
+      "iso639_3": "epo",
+      "name": [
+        "Esperanto"
+      ],
+      "nativeName": [
+        "Esperanto"
+      ],
+      "direction": "LTR",
+      "family": "Constructed"
+    },
+    {
+      "iso639_1": "et",
+      "iso639_2": "est",
+      "iso639_2en": "est",
+      "iso639_3": "est",
+      "name": [
+        "Estonian"
+      ],
+      "nativeName": [
+        "eesti",
+        "eesti keel"
+      ],
+      "direction": "LTR",
+      "family": "Uralic",
+      "countries": [
+        "EST"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "et-EE",
+          "displayName": "Estonian - Estonia",
+          "cultureCode": "0x0425"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ee",
+      "iso639_2": "ewe",
+      "iso639_2en": "ewe",
+      "iso639_3": "ewe",
+      "name": [
+        "Ewe"
+      ],
+      "nativeName": [
+        "Eʋegbe"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "GHA",
+        "TGO"
+      ]
+    },
+    {
+      "iso639_1": "fo",
+      "iso639_2": "fao",
+      "iso639_2en": "fao",
+      "iso639_3": "fao",
+      "name": [
+        "Faroese"
+      ],
+      "nativeName": [
+        "føroyskt"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "langCultureMs": [
+        {
+          "langCultureName": "fo-FO",
+          "displayName": "Faroese - Faroe Islands",
+          "cultureCode": "0x0438"
+        }
+      ]
+    },
+    {
+      "iso639_1": "fj",
+      "iso639_2": "fij",
+      "iso639_2en": "fij",
+      "iso639_3": "fij",
+      "name": [
+        "Fijian"
+      ],
+      "nativeName": [
+        "vosa Vakaviti"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "FJI"
+      ]
+    },
+    {
+      "iso639_1": "fi",
+      "iso639_2": "fin",
+      "iso639_2en": "fin",
+      "iso639_3": "fin",
+      "name": [
+        "Finnish"
+      ],
+      "nativeName": [
+        "suomi",
+        "suomen kieli"
+      ],
+      "direction": "LTR",
+      "family": "Uralic",
+      "countries": [
+        "FIN"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "fi-FI",
+          "displayName": "Finnish - Finland",
+          "cultureCode": "0x040B"
+        }
+      ]
+    },
+    {
+      "iso639_1": "fr",
+      "iso639_2": "fra",
+      "iso639_2en": "fre",
+      "iso639_3": "fra",
+      "name": [
+        "French"
+      ],
+      "nativeName": [
+        "français",
+        "langue française"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "BEL",
+        "BEN",
+        "BFA",
+        "BDI",
+        "CMR",
+        "CAN",
+        "CAF",
+        "TCD",
+        "COM",
+        "CIV",
+        "COD",
+        "COG",
+        "DJI",
+        "GNQ",
+        "FRA",
+        "GUF",
+        "PYF",
+        "GLP",
+        "MTQ",
+        "MYT",
+        "NCL",
+        "REU",
+        "BLM",
+        "SPM",
+        "WLF",
+        "GAB",
+        "GIN",
+        "HTI",
+        "ITA",
+        "JEY",
+        "LUX",
+        "MDG",
+        "MLI",
+        "MUS",
+        "MCO",
+        "NER",
+        "RWA",
+        "SEN",
+        "SYC",
+        "CHE",
+        "TGO",
+        "VUT"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "fr-BE",
+          "displayName": "French - Belgium",
+          "cultureCode": "0x080C"
+        },
+        {
+          "langCultureName": "fr-CA",
+          "displayName": "French - Canada",
+          "cultureCode": "0x0C0C"
+        },
+        {
+          "langCultureName": "fr-FR",
+          "displayName": "French - France",
+          "cultureCode": "0x040C"
+        },
+        {
+          "langCultureName": "fr-LU",
+          "displayName": "French - Luxembourg",
+          "cultureCode": "0x140C"
+        },
+        {
+          "langCultureName": "fr-MC",
+          "displayName": "French - Monaco",
+          "cultureCode": "0x180C"
+        },
+        {
+          "langCultureName": "fr-CH",
+          "displayName": "French - Switzerland",
+          "cultureCode": "0x100C"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ff",
+      "iso639_2": "ful",
+      "iso639_2en": "ful",
+      "iso639_3": "ful",
+      "name": [
+        "Fula",
+        "Fulah",
+        "Pulaar",
+        "Pular"
+      ],
+      "nativeName": [
+        "Fulfulde",
+        "Pulaar",
+        "Pular"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "BEN",
+        "BFA",
+        "MLI",
+        "NER",
+        "SEN"
+      ]
+    },
+    {
+      "iso639_1": "gl",
+      "iso639_2": "glg",
+      "iso639_2en": "glg",
+      "iso639_3": "glg",
+      "name": [
+        "Galician"
+      ],
+      "nativeName": [
+        "galego"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "langCultureMs": [
+        {
+          "langCultureName": "gl-ES",
+          "displayName": "Galician - Galician",
+          "cultureCode": "0x0456"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ka",
+      "iso639_2": "kat",
+      "iso639_2en": "geo",
+      "iso639_3": "kat",
+      "name": [
+        "Georgian"
+      ],
+      "nativeName": [
+        "ქართული"
+      ],
+      "direction": "LTR",
+      "family": "South Caucasian",
+      "countries": [
+        "GEO"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ka-GE",
+          "displayName": "Georgian - Georgia",
+          "cultureCode": "0x0437"
+        }
+      ]
+    },
+    {
+      "iso639_1": "de",
+      "iso639_2": "deu",
+      "iso639_2en": "ger",
+      "iso639_3": "deu",
+      "name": [
+        "German"
+      ],
+      "nativeName": [
+        "Deutsch"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "AUT",
+        "BEL",
+        "DEU",
+        "LIE",
+        "LUX",
+        "ITA",
+        "CHE"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "de-AT",
+          "displayName": "German - Austria",
+          "cultureCode": "0x0C07"
+        },
+        {
+          "langCultureName": "de-DE",
+          "displayName": "German - Germany",
+          "cultureCode": "0x0407"
+        },
+        {
+          "langCultureName": "de-LI",
+          "displayName": "German - Liechtenstein",
+          "cultureCode": "0x1407"
+        },
+        {
+          "langCultureName": "de-LU",
+          "displayName": "German - Luxembourg",
+          "cultureCode": "0x1007"
+        },
+        {
+          "langCultureName": "de-CH",
+          "displayName": "German - Switzerland",
+          "cultureCode": "0x0807"
+        }
+      ]
+    },
+    {
+      "iso639_1": "el",
+      "iso639_2": "ell",
+      "iso639_2en": "gre",
+      "iso639_3": "ell",
+      "name": [
+        "Greek"
+      ],
+      "nativeName": [
+        "ελληνικά"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "GRC",
+        "CYP"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "el-GR",
+          "displayName": "Greek - Greece",
+          "cultureCode": "0x0408"
+        }
+      ]
+    },
+    {
+      "iso639_1": "gn",
+      "iso639_2": "grn",
+      "iso639_2en": "grn",
+      "iso639_3": "grn",
+      "name": [
+        "Guaraní"
+      ],
+      "nativeName": [
+        "Avañe'ẽ"
+      ],
+      "direction": "LTR",
+      "family": "Tupian",
+      "countries": [
+        "PRY",
+        "BOL"
+      ]
+    },
+    {
+      "iso639_1": "gu",
+      "iso639_2": "guj",
+      "iso639_2en": "guj",
+      "iso639_3": "guj",
+      "name": [
+        "Gujarati"
+      ],
+      "nativeName": [
+        "ગુજરાતી"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "IND"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "gu-IN",
+          "displayName": "Gujarati - India",
+          "cultureCode": "0x0447"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ht",
+      "iso639_2": "hat",
+      "iso639_2en": "hat",
+      "iso639_3": "hat",
+      "name": [
+        "Haitian",
+        "Haitian Creole"
+      ],
+      "nativeName": [
+        "Kreyòl ayisyen"
+      ],
+      "direction": "LTR",
+      "family": "Creole",
+      "countries": [
+        "HTI"
+      ]
+    },
+    {
+      "iso639_1": "ha",
+      "iso639_2": "hau",
+      "iso639_2en": "hau",
+      "iso639_3": "hau",
+      "name": [
+        "Hausa"
+      ],
+      "nativeName": [
+        "(Hausa) هَوُسَ"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "NER",
+        "NGA"
+      ]
+    },
+    {
+      "iso639_1": "he",
+      "iso639_2": "heb",
+      "iso639_2en": "heb",
+      "iso639_3": "heb",
+      "name": [
+        "Hebrew"
+      ],
+      "nativeName": [
+        "עברית"
+      ],
+      "direction": "RTL",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "ISR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "he-IL",
+          "displayName": "Hebrew - Israel",
+          "cultureCode": "0x040D"
+        }
+      ]
+    },
+    {
+      "iso639_1": "hz",
+      "iso639_2": "her",
+      "iso639_2en": "her",
+      "iso639_3": "her",
+      "name": [
+        "Herero"
+      ],
+      "nativeName": [
+        "Otjiherero"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo"
+    },
+    {
+      "iso639_1": "hi",
+      "iso639_2": "hin",
+      "iso639_2en": "hin",
+      "iso639_3": "hin",
+      "name": [
+        "Hindi"
+      ],
+      "nativeName": [
+        "हिन्दी",
+        "हिंदी"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "IND",
+        "FJI"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "hi-IN",
+          "displayName": "Hindi - India",
+          "cultureCode": "0x0439"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ho",
+      "iso639_2": "hmo",
+      "iso639_2en": "hmo",
+      "iso639_3": "hmo",
+      "name": [
+        "Hiri Motu"
+      ],
+      "nativeName": [
+        "Hiri Motu"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "PNG"
+      ]
+    },
+    {
+      "iso639_1": "hu",
+      "iso639_2": "hun",
+      "iso639_2en": "hun",
+      "iso639_3": "hun",
+      "name": [
+        "Hungarian"
+      ],
+      "nativeName": [
+        "magyar"
+      ],
+      "direction": "LTR",
+      "family": "Uralic",
+      "countries": [
+        "HUN"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "hu-HU",
+          "displayName": "Hungarian - Hungary",
+          "cultureCode": "0x040E"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ia",
+      "iso639_2": "ina",
+      "iso639_2en": "ina",
+      "iso639_3": "ina",
+      "name": [
+        "Interlingua"
+      ],
+      "nativeName": [
+        "Interlingua"
+      ],
+      "direction": "LTR",
+      "family": "Constructed"
+    },
+    {
+      "iso639_1": "id",
+      "iso639_2": "ind",
+      "iso639_2en": "ind",
+      "iso639_3": "ind",
+      "name": [
+        "Indonesian"
+      ],
+      "nativeName": [
+        "Bahasa Indonesia"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "IDN"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "id-ID",
+          "displayName": "Indonesian - Indonesia",
+          "cultureCode": "0x0421"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ie",
+      "iso639_2": "ile",
+      "iso639_2en": "ile",
+      "iso639_3": "ile",
+      "name": [
+        "Interlingue"
+      ],
+      "nativeName": [
+        "Interlingue"
+      ],
+      "direction": "LTR",
+      "family": "Constructed"
+    },
+    {
+      "iso639_1": "ga",
+      "iso639_2": "gle",
+      "iso639_2en": "gle",
+      "iso639_3": "gle",
+      "name": [
+        "Irish"
+      ],
+      "nativeName": [
+        "Gaeilge"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "IRL"
+      ]
+    },
+    {
+      "iso639_1": "ig",
+      "iso639_2": "ibo",
+      "iso639_2en": "ibo",
+      "iso639_3": "ibo",
+      "name": [
+        "Igbo"
+      ],
+      "nativeName": [
+        "Asụsụ Igbo"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "NGA"
+      ]
+    },
+    {
+      "iso639_1": "ik",
+      "iso639_2": "ipk",
+      "iso639_2en": "ipk",
+      "iso639_3": "ipk",
+      "name": [
+        "Inupiaq"
+      ],
+      "nativeName": [
+        "Iñupiaq",
+        "Iñupiatun"
+      ],
+      "direction": "LTR",
+      "family": "Eskimo–Aleut"
+    },
+    {
+      "iso639_1": "io",
+      "iso639_2": "ido",
+      "iso639_2en": "ido",
+      "iso639_3": "ido",
+      "name": [
+        "Ido"
+      ],
+      "nativeName": [
+        "Ido"
+      ],
+      "direction": "LTR",
+      "family": "Constructed"
+    },
+    {
+      "iso639_1": "is",
+      "iso639_2": "isl",
+      "iso639_2en": "ice",
+      "iso639_3": "isl",
+      "name": [
+        "Icelandic"
+      ],
+      "nativeName": [
+        "Íslenska"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ISL"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "is-IS",
+          "displayName": "Icelandic - Iceland",
+          "cultureCode": "0x040F"
+        }
+      ]
+    },
+    {
+      "iso639_1": "it",
+      "iso639_2": "ita",
+      "iso639_2en": "ita",
+      "iso639_3": "ita",
+      "name": [
+        "Italian"
+      ],
+      "nativeName": [
+        "italiano"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ITA",
+        "HRV",
+        "SMR",
+        "SVN",
+        "CHE",
+        "VAT"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "it-IT",
+          "displayName": "Italian - Italy",
+          "cultureCode": "0x0410"
+        },
+        {
+          "langCultureName": "it-CH",
+          "displayName": "Italian - Switzerland",
+          "cultureCode": "0x0810"
+        }
+      ]
+    },
+    {
+      "iso639_1": "iu",
+      "iso639_2": "iku",
+      "iso639_2en": "iku",
+      "iso639_3": "iku",
+      "name": [
+        "Inuktitut"
+      ],
+      "nativeName": [
+        "ᐃᓄᒃᑎᑐᑦ"
+      ],
+      "direction": "LTR",
+      "family": "Eskimo–Aleut"
+    },
+    {
+      "iso639_1": "ja",
+      "iso639_2": "jpn",
+      "iso639_2en": "jpn",
+      "iso639_3": "jpn",
+      "name": [
+        "Japanese"
+      ],
+      "nativeName": [
+        "日本語 (にほんご)"
+      ],
+      "direction": "LTR",
+      "family": "Japonic",
+      "countries": [
+        "JPN"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ja-JP",
+          "displayName": "Japanese - Japan",
+          "cultureCode": "0x0411"
+        }
+      ]
+    },
+    {
+      "iso639_1": "jv",
+      "iso639_2": "jav",
+      "iso639_2en": "jav",
+      "iso639_3": "jav",
+      "name": [
+        "Javanese"
+      ],
+      "nativeName": [
+        "basa Jawa"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian"
+    },
+    {
+      "iso639_1": "kl",
+      "iso639_2": "kal",
+      "iso639_2en": "kal",
+      "iso639_3": "kal",
+      "name": [
+        "Kalaallisut",
+        "Greenlandic"
+      ],
+      "nativeName": [
+        "kalaallisut",
+        "kalaallit oqaasii"
+      ],
+      "direction": "LTR",
+      "family": "Eskimo–Aleut"
+    },
+    {
+      "iso639_1": "kn",
+      "iso639_2": "kan",
+      "iso639_2en": "kan",
+      "iso639_3": "kan",
+      "name": [
+        "Kannada"
+      ],
+      "nativeName": [
+        "ಕನ್ನಡ"
+      ],
+      "direction": "LTR",
+      "family": "Dravidian",
+      "langCultureMs": [
+        {
+          "langCultureName": "kn-IN",
+          "displayName": "Kannada - India",
+          "cultureCode": "0x044B"
+        }
+      ]
+    },
+    {
+      "iso639_1": "kr",
+      "iso639_2": "kau",
+      "iso639_2en": "kau",
+      "iso639_3": "kau",
+      "name": [
+        "Kanuri"
+      ],
+      "nativeName": [
+        "Kanuri"
+      ],
+      "direction": "LTR",
+      "family": "Nilo-Saharan",
+      "countries": [
+        "NER"
+      ]
+    },
+    {
+      "iso639_1": "ks",
+      "iso639_2": "kas",
+      "iso639_2en": "kas",
+      "iso639_3": "kas",
+      "name": [
+        "Kashmiri"
+      ],
+      "nativeName": [
+        "कश्मीरी",
+        "كشميري‎"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "kk",
+      "iso639_2": "kaz",
+      "iso639_2en": "kaz",
+      "iso639_3": "kaz",
+      "name": [
+        "Kazakh"
+      ],
+      "nativeName": [
+        "қазақ тілі"
+      ],
+      "direction": "LTR",
+      "family": "Turkic",
+      "countries": [
+        "KAZ"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "kk-KZ",
+          "displayName": "Kazakh - Kazakhstan",
+          "cultureCode": "0x043F"
+        }
+      ]
+    },
+    {
+      "iso639_1": "km",
+      "iso639_2": "khm",
+      "iso639_2en": "khm",
+      "iso639_3": "khm",
+      "name": [
+        "Khmer"
+      ],
+      "nativeName": [
+        "ខ្មែរ",
+        "ខេមរភាសា",
+        "ភាសាខ្មែរ"
+      ],
+      "direction": "LTR",
+      "family": "Austroasiatic",
+      "countries": [
+        "KHM"
+      ]
+    },
+    {
+      "iso639_1": "ki",
+      "iso639_2": "kik",
+      "iso639_2en": "kik",
+      "iso639_3": "kik",
+      "name": [
+        "Kikuyu",
+        "Gikuyu"
+      ],
+      "nativeName": [
+        "Gĩkũyũ"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo"
+    },
+    {
+      "iso639_1": "rw",
+      "iso639_2": "kin",
+      "iso639_2en": "kin",
+      "iso639_3": "kin",
+      "name": [
+        "Kinyarwanda"
+      ],
+      "nativeName": [
+        "Ikinyarwanda"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "RWA"
+      ]
+    },
+    {
+      "iso639_1": "ky",
+      "iso639_2": "kir",
+      "iso639_2en": "kir",
+      "iso639_3": "kir",
+      "name": [
+        "Kyrgyz"
+      ],
+      "nativeName": [
+        "Кыргызча",
+        "Кыргыз тили"
+      ],
+      "direction": "LTR",
+      "family": "Turkic",
+      "countries": [
+        "KGZ"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ky-KZ",
+          "displayName": "Kyrgyz - Kazakhstan",
+          "cultureCode": "0x0440"
+        }
+      ]
+    },
+    {
+      "iso639_1": "kv",
+      "iso639_2": "kom",
+      "iso639_2en": "kom",
+      "iso639_3": "kom",
+      "name": [
+        "Komi"
+      ],
+      "nativeName": [
+        "коми кыв"
+      ],
+      "direction": "LTR",
+      "family": "Uralic"
+    },
+    {
+      "iso639_1": "kg",
+      "iso639_2": "kon",
+      "iso639_2en": "kon",
+      "iso639_3": "kon",
+      "name": [
+        "Kongo"
+      ],
+      "nativeName": [
+        "Kikongo"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "AGO",
+        "COD",
+        "COG"
+      ]
+    },
+    {
+      "iso639_1": "ko",
+      "iso639_2": "kor",
+      "iso639_2en": "kor",
+      "iso639_3": "kor",
+      "name": [
+        "Korean"
+      ],
+      "nativeName": [
+        "한국어",
+        "조선어"
+      ],
+      "direction": "LTR",
+      "family": "Koreanic",
+      "countries": [
+        "PRK",
+        "KOR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ko-KR",
+          "displayName": "Korean - Korea",
+          "cultureCode": "0x0412"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ku",
+      "iso639_2": "kur",
+      "iso639_2en": "kur",
+      "iso639_3": "kur",
+      "name": [
+        "Kurdish"
+      ],
+      "nativeName": [
+        "Kurdî",
+        "كوردی‎"
+      ],
+      "direction": "RTL",
+      "family": "Indo-European",
+      "countries": [
+        "IRQ"
+      ]
+    },
+    {
+      "iso639_1": "kj",
+      "iso639_2": "kua",
+      "iso639_2en": "kua",
+      "iso639_3": "kua",
+      "name": [
+        "Kwanyama",
+        "Kuanyama"
+      ],
+      "nativeName": [
+        "Kuanyama"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "AGO"
+      ]
+    },
+    {
+      "iso639_1": "la",
+      "iso639_2": "lat",
+      "iso639_2en": "lat",
+      "iso639_3": "lat",
+      "name": [
+        "Latin"
+      ],
+      "nativeName": [
+        "latine",
+        "lingua latina"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "VAT"
+      ]
+    },
+    {
+      "iso639_1": "lb",
+      "iso639_2": "ltz",
+      "iso639_2en": "ltz",
+      "iso639_3": "ltz",
+      "name": [
+        "Luxembourgish",
+        "Letzeburgesch"
+      ],
+      "nativeName": [
+        "Lëtzebuergesch"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "LUX"
+      ]
+    },
+    {
+      "iso639_1": "lg",
+      "iso639_2": "lug",
+      "iso639_2en": "lug",
+      "iso639_3": "lug",
+      "name": [
+        "Ganda"
+      ],
+      "nativeName": [
+        "Luganda"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo"
+    },
+    {
+      "iso639_1": "li",
+      "iso639_2": "lim",
+      "iso639_2en": "lim",
+      "iso639_3": "lim",
+      "name": [
+        "Limburgish",
+        "Limburgan",
+        "Limburger"
+      ],
+      "nativeName": [
+        "Limburgs"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "ln",
+      "iso639_2": "lin",
+      "iso639_2en": "lin",
+      "iso639_3": "lin",
+      "name": [
+        "Lingala"
+      ],
+      "nativeName": [
+        "Lingála"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "COD",
+        "COG"
+      ]
+    },
+    {
+      "iso639_1": "lo",
+      "iso639_2": "lao",
+      "iso639_2en": "lao",
+      "iso639_3": "lao",
+      "name": [
+        "Lao"
+      ],
+      "nativeName": [
+        "ພາສາລາວ"
+      ],
+      "direction": "LTR",
+      "family": "Tai–Kadai",
+      "countries": [
+        "LAO"
+      ]
+    },
+    {
+      "iso639_1": "lt",
+      "iso639_2": "lit",
+      "iso639_2en": "lit",
+      "iso639_3": "lit",
+      "name": [
+        "Lithuanian"
+      ],
+      "nativeName": [
+        "lietuvių kalba"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "LTU"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "lt-LT",
+          "displayName": "Lithuanian - Lithuania",
+          "cultureCode": "0x0427"
+        }
+      ]
+    },
+    {
+      "iso639_1": "lu",
+      "iso639_2": "lub",
+      "iso639_2en": "lub",
+      "iso639_3": "lub",
+      "name": [
+        "Luba-Katanga"
+      ],
+      "nativeName": [
+        "Tshiluba"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "COD"
+      ]
+    },
+    {
+      "iso639_1": "lv",
+      "iso639_2": "lav",
+      "iso639_2en": "lav",
+      "iso639_3": "lav",
+      "name": [
+        "Latvian"
+      ],
+      "nativeName": [
+        "latviešu valoda"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "LVA"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "lv-LV",
+          "displayName": "Latvian - Latvia",
+          "cultureCode": "0x0426"
+        }
+      ]
+    },
+    {
+      "iso639_1": "gv",
+      "iso639_2": "glv",
+      "iso639_2en": "glv",
+      "iso639_3": "glv",
+      "name": [
+        "Manx"
+      ],
+      "nativeName": [
+        "Gaelg",
+        "Gailck"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "mk",
+      "iso639_2": "mkd",
+      "iso639_2en": "mac",
+      "iso639_3": "mkd",
+      "name": [
+        "Macedonian"
+      ],
+      "nativeName": [
+        "македонски јазик"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "MKD"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "mk-MK",
+          "displayName": "Macedonian (FYROM)",
+          "cultureCode": "0x042F"
+        }
+      ]
+    },
+    {
+      "iso639_1": "mg",
+      "iso639_2": "mlg",
+      "iso639_2en": "mlg",
+      "iso639_3": "mlg",
+      "name": [
+        "Malagasy"
+      ],
+      "nativeName": [
+        "fiteny malagasy"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "MDG"
+      ]
+    },
+    {
+      "iso639_1": "ms",
+      "iso639_2": "msa",
+      "iso639_2en": "may",
+      "iso639_3": "msa",
+      "name": [
+        "Malay"
+      ],
+      "nativeName": [
+        "bahasa Melayu",
+        "بهاس ملايو‎"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "MYS",
+        "BRN",
+        "SGP",
+        "IDN"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ms-BN",
+          "displayName": "Malay - Brunei",
+          "cultureCode": "0x083E"
+        },
+        {
+          "langCultureName": "ms-MY",
+          "displayName": "Malay - Malaysia",
+          "cultureCode": "0x043E"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ml",
+      "iso639_2": "mal",
+      "iso639_2en": "mal",
+      "iso639_3": "mal",
+      "name": [
+        "Malayalam"
+      ],
+      "nativeName": [
+        "മലയാളം"
+      ],
+      "direction": "LTR",
+      "family": "Dravidian"
+    },
+    {
+      "iso639_1": "mt",
+      "iso639_2": "mlt",
+      "iso639_2en": "mlt",
+      "iso639_3": "mlt",
+      "name": [
+        "Maltese"
+      ],
+      "nativeName": [
+        "Malti"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "MLT"
+      ]
+    },
+    {
+      "iso639_1": "mi",
+      "iso639_2": "mri",
+      "iso639_2en": "mao",
+      "iso639_3": "mri",
+      "name": [
+        "Māori"
+      ],
+      "nativeName": [
+        "te reo Māori"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "NZL"
+      ]
+    },
+    {
+      "iso639_1": "mr",
+      "iso639_2": "mar",
+      "iso639_2en": "mar",
+      "iso639_3": "mar",
+      "name": [
+        "Marathi (Marāṭhī)"
+      ],
+      "nativeName": [
+        "मराठी"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "langCultureMs": [
+        {
+          "langCultureName": "mr-IN",
+          "displayName": "Marathi - India",
+          "cultureCode": "0x044E"
+        }
+      ]
+    },
+    {
+      "iso639_1": "mh",
+      "iso639_2": "mah",
+      "iso639_2en": "mah",
+      "iso639_3": "mah",
+      "name": [
+        "Marshallese"
+      ],
+      "nativeName": [
+        "Kajin M̧ajeļ"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "MHL"
+      ]
+    },
+    {
+      "iso639_1": "mn",
+      "iso639_2": "mon",
+      "iso639_2en": "mon",
+      "iso639_3": "mon",
+      "name": [
+        "Mongolian"
+      ],
+      "nativeName": [
+        "монгол"
+      ],
+      "direction": "LTR",
+      "family": "Mongolic",
+      "countries": [
+        "MNG"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "mn-MN",
+          "displayName": "Mongolian - Mongolia",
+          "cultureCode": "0x0450"
+        }
+      ]
+    },
+    {
+      "iso639_1": "na",
+      "iso639_2": "nau",
+      "iso639_2en": "nau",
+      "iso639_3": "nau",
+      "name": [
+        "Nauru"
+      ],
+      "nativeName": [
+        "Ekakairũ Naoero"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian"
+    },
+    {
+      "iso639_1": "nv",
+      "iso639_2": "nav",
+      "iso639_2en": "nav",
+      "iso639_3": "nav",
+      "name": [
+        "Navajo",
+        "Navaho"
+      ],
+      "nativeName": [
+        "Diné bizaad",
+        "Dinékʼehǰí"
+      ],
+      "direction": "LTR",
+      "family": "Dené–Yeniseian"
+    },
+    {
+      "iso639_1": "nb",
+      "iso639_2": "nob",
+      "iso639_2en": "nob",
+      "iso639_3": "nob",
+      "name": [
+        "Norwegian Bokmål"
+      ],
+      "nativeName": [
+        "Norsk bokmål"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "NOR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "nb-NO",
+          "displayName": "Norwegian (Bokmål) - Norway",
+          "cultureCode": "0x0414"
+        }
+      ]
+    },
+    {
+      "iso639_1": "nd",
+      "iso639_2": "nde",
+      "iso639_2en": "nde",
+      "iso639_3": "nde",
+      "name": [
+        "Northern Ndebele"
+      ],
+      "nativeName": [
+        "isiNdebele"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "ZAF",
+        "ZWE"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nso",
+      "iso639_2en": "nso",
+      "iso639_3": "nso",
+      "name": [
+        "Northern Sotho"
+      ],
+      "nativeName": [
+        "Sesotho sa Leboa"
+      ],
+      "direction": "LTR",
+      "family": "Niger-Congo",
+      "countries": [
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "ne",
+      "iso639_2": "nep",
+      "iso639_2en": "nep",
+      "iso639_3": "nep",
+      "name": [
+        "Nepali"
+      ],
+      "nativeName": [
+        "नेपाली"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "NPL"
+      ]
+    },
+    {
+      "iso639_1": "ng",
+      "iso639_2": "ndo",
+      "iso639_2en": "ndo",
+      "iso639_3": "ndo",
+      "name": [
+        "Ndonga"
+      ],
+      "nativeName": [
+        "Owambo"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo"
+    },
+    {
+      "iso639_1": "nn",
+      "iso639_2": "nno",
+      "iso639_2en": "nno",
+      "iso639_3": "nno",
+      "name": [
+        "Norwegian Nynorsk"
+      ],
+      "nativeName": [
+        "Norsk nynorsk"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "NOR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "nn-NO",
+          "displayName": "Norwegian (Nynorsk) - Norway",
+          "cultureCode": "0x0814"
+        }
+      ]
+    },
+    {
+      "iso639_1": "no",
+      "iso639_2": "nor",
+      "iso639_2en": "nor",
+      "iso639_3": "nor",
+      "name": [
+        "Norwegian"
+      ],
+      "nativeName": [
+        "Norsk"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "NOR"
+      ]
+    },
+    {
+      "iso639_1": "ii",
+      "iso639_2": "iii",
+      "iso639_2en": "iii",
+      "iso639_3": "iii",
+      "name": [
+        "Nuosu"
+      ],
+      "nativeName": [
+        "Nuosuhxop"
+      ],
+      "direction": "LTR",
+      "family": "Sino-Tibetan"
+    },
+    {
+      "iso639_1": "nr",
+      "iso639_2": "nbl",
+      "iso639_2en": "nbl",
+      "iso639_3": "nbl",
+      "name": [
+        "Southern Ndebele"
+      ],
+      "nativeName": [
+        "isiNdebele"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "oc",
+      "iso639_2": "oci",
+      "iso639_2en": "oci",
+      "iso639_3": "oci",
+      "name": [
+        "Occitan"
+      ],
+      "nativeName": [
+        "occitan",
+        "lenga d'òc"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "oj",
+      "iso639_2": "oji",
+      "iso639_2en": "oji",
+      "iso639_3": "oji",
+      "name": [
+        "Ojibwe",
+        "Ojibwa"
+      ],
+      "nativeName": [
+        "ᐊᓂᔑᓈᐯᒧᐎᓐ"
+      ],
+      "direction": "LTR",
+      "family": "Algonquian"
+    },
+    {
+      "iso639_1": "cu",
+      "iso639_2": "chu",
+      "iso639_2en": "chu",
+      "iso639_3": "chu",
+      "name": [
+        "Old Church Slavonic",
+        "Church Slavonic",
+        "Old Bulgarian"
+      ],
+      "nativeName": [
+        "ѩзыкъ словѣньскъ"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "om",
+      "iso639_2": "orm",
+      "iso639_2en": "orm",
+      "iso639_3": "orm",
+      "name": [
+        "Oromo"
+      ],
+      "nativeName": [
+        "Afaan Oromoo"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic"
+    },
+    {
+      "iso639_1": "or",
+      "iso639_2": "ori",
+      "iso639_2en": "ori",
+      "iso639_3": "ori",
+      "name": [
+        "Oriya"
+      ],
+      "nativeName": [
+        "ଓଡ଼ିଆ"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "os",
+      "iso639_2": "oss",
+      "iso639_2en": "oss",
+      "iso639_3": "oss",
+      "name": [
+        "Ossetian",
+        "Ossetic"
+      ],
+      "nativeName": [
+        "ирон æвзаг"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": []
+    },
+    {
+      "iso639_1": "pa",
+      "iso639_2": "pan",
+      "iso639_2en": "pan",
+      "iso639_3": "pan",
+      "name": [
+        "Panjabi",
+        "Punjabi"
+      ],
+      "nativeName": [
+        "ਪੰਜਾਬੀ",
+        "پنجابی‎"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "IND"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "pa-IN",
+          "displayName": "Punjabi - India",
+          "cultureCode": "0x0446"
+        }
+      ]
+    },
+    {
+      "iso639_1": "pi",
+      "iso639_2": "pli",
+      "iso639_2en": "pli",
+      "iso639_3": "pli",
+      "name": [
+        "Pāli"
+      ],
+      "nativeName": [
+        "पाऴि"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "fa",
+      "iso639_2": "fas",
+      "iso639_2en": "per",
+      "iso639_3": "fas",
+      "name": [
+        "Persian",
+        "Farsi"
+      ],
+      "nativeName": [
+        "فارسی"
+      ],
+      "direction": "RTL",
+      "family": "Indo-European",
+      "countries": [
+        "IRN",
+        "AFG",
+        "TJK"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "fa-IR",
+          "displayName": "Farsi - Iran",
+          "cultureCode": "0x0429"
+        }
+      ]
+    },
+    {
+      "iso639_1": "pl",
+      "iso639_2": "pol",
+      "iso639_2en": "pol",
+      "iso639_3": "pol",
+      "name": [
+        "Polish"
+      ],
+      "nativeName": [
+        "język polski",
+        "polszczyzna"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "POL"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "pl-PL",
+          "displayName": "Polish - Poland",
+          "cultureCode": "0x0415"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ps",
+      "iso639_2": "pus",
+      "iso639_2en": "pus",
+      "iso639_3": "pus",
+      "name": [
+        "Pashto",
+        "Pushto"
+      ],
+      "nativeName": [
+        "پښتو"
+      ],
+      "direction": "RTL",
+      "family": "Indo-European",
+      "countries": [
+        "AFG"
+      ]
+    },
+    {
+      "iso639_1": "pt",
+      "iso639_2": "por",
+      "iso639_2en": "por",
+      "iso639_3": "por",
+      "name": [
+        "Portuguese"
+      ],
+      "nativeName": [
+        "português"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "AGO",
+        "BRA",
+        "CPV",
+        "TLS",
+        "GNQ",
+        "GNB",
+        "MAC",
+        "MOZ",
+        "PRT",
+        "STP"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "pt-BR",
+          "displayName": "Portuguese - Brazil",
+          "cultureCode": "0x0416"
+        },
+        {
+          "langCultureName": "pt-PT",
+          "displayName": "Portuguese - Portugal",
+          "cultureCode": "0x0816"
+        }
+      ]
+    },
+    {
+      "iso639_1": "qu",
+      "iso639_2": "que",
+      "iso639_2en": "que",
+      "iso639_3": "que",
+      "name": [
+        "Quechua"
+      ],
+      "nativeName": [
+        "Runa Simi",
+        "Kichwa"
+      ],
+      "direction": "LTR",
+      "family": "Quechuan",
+      "countries": [
+        "BOL",
+        "PER"
+      ]
+    },
+    {
+      "iso639_1": "rm",
+      "iso639_2": "roh",
+      "iso639_2en": "roh",
+      "iso639_3": "roh",
+      "name": [
+        "Romansh"
+      ],
+      "nativeName": [
+        "rumantsch grischun"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "CHE"
+      ]
+    },
+    {
+      "iso639_1": "rn",
+      "iso639_2": "run",
+      "iso639_2en": "run",
+      "iso639_3": "run",
+      "name": [
+        "Kirundi"
+      ],
+      "nativeName": [
+        "Ikirundi"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "BDI"
+      ]
+    },
+    {
+      "iso639_1": "ro",
+      "iso639_2": "ron",
+      "iso639_2en": "rum",
+      "iso639_3": "ron",
+      "name": [
+        "Romanian"
+      ],
+      "nativeName": [
+        "limba română"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ROU",
+        "MDA"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ro-RO",
+          "displayName": "Romanian - Romania",
+          "cultureCode": "0x0418"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ru",
+      "iso639_2": "rus",
+      "iso639_2en": "rus",
+      "iso639_3": "rus",
+      "name": [
+        "Russian"
+      ],
+      "nativeName": [
+        "русский язык"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "RUS",
+        "BLR",
+        "KAZ",
+        "KGZ",
+        "TJK"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ru-RU",
+          "displayName": "Russian - Russia",
+          "cultureCode": "0x0419"
+        }
+      ]
+    },
+    {
+      "iso639_1": "sa",
+      "iso639_2": "san",
+      "iso639_2en": "san",
+      "iso639_3": "san",
+      "name": [
+        "Sanskrit (Saṁskṛta)"
+      ],
+      "nativeName": [
+        "संस्कृतम्"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "langCultureMs": [
+        {
+          "langCultureName": "sa-IN",
+          "displayName": "Sanskrit - India",
+          "cultureCode": "0x044F"
+        }
+      ]
+    },
+    {
+      "iso639_1": "sc",
+      "iso639_2": "srd",
+      "iso639_2en": "srd",
+      "iso639_3": "srd",
+      "name": [
+        "Sardinian"
+      ],
+      "nativeName": [
+        "sardu"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "sd",
+      "iso639_2": "snd",
+      "iso639_2en": "snd",
+      "iso639_3": "snd",
+      "name": [
+        "Sindhi"
+      ],
+      "nativeName": [
+        "सिन्धी",
+        "سنڌي، سندھی‎"
+      ],
+      "direction": "RTL",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "se",
+      "iso639_2": "sme",
+      "iso639_2en": "sme",
+      "iso639_3": "sme",
+      "name": [
+        "Northern Sami"
+      ],
+      "nativeName": [
+        "Davvisámegiella"
+      ],
+      "direction": "LTR",
+      "family": "Uralic"
+    },
+    {
+      "iso639_1": "sm",
+      "iso639_2": "smo",
+      "iso639_2en": "smo",
+      "iso639_3": "smo",
+      "name": [
+        "Samoan"
+      ],
+      "nativeName": [
+        "gagana fa'a Samoa"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian"
+    },
+    {
+      "iso639_1": "sg",
+      "iso639_2": "sag",
+      "iso639_2en": "sag",
+      "iso639_3": "sag",
+      "name": [
+        "Sango"
+      ],
+      "nativeName": [
+        "yângâ tî sängö"
+      ],
+      "direction": "LTR",
+      "family": "Creole",
+      "countries": [
+        "CAF"
+      ]
+    },
+    {
+      "iso639_1": "sr",
+      "iso639_2": "srp",
+      "iso639_2en": "srp",
+      "iso639_3": "srp",
+      "name": [
+        "Serbian"
+      ],
+      "nativeName": [
+        "српски језик"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "SRB",
+        "BIH"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "Cy-sr-SP",
+          "displayName": "Serbian (Cyrillic) - Serbia",
+          "cultureCode": "0x0C1A"
+        },
+        {
+          "langCultureName": "Lt-sr-SP",
+          "displayName": "Serbian (Latin) - Serbia",
+          "cultureCode": "0x081A"
+        }
+      ]
+    },
+    {
+      "iso639_1": "gd",
+      "iso639_2": "gla",
+      "iso639_2en": "gla",
+      "iso639_3": "gla",
+      "name": [
+        "Scottish Gaelic",
+        "Gaelic"
+      ],
+      "nativeName": [
+        "Gàidhlig"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "sn",
+      "iso639_2": "sna",
+      "iso639_2en": "sna",
+      "iso639_3": "sna",
+      "name": [
+        "Shona"
+      ],
+      "nativeName": [
+        "chiShona"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "ZWE"
+      ]
+    },
+    {
+      "iso639_1": "si",
+      "iso639_2": "sin",
+      "iso639_2en": "sin",
+      "iso639_3": "sin",
+      "name": [
+        "Sinhala",
+        "Sinhalese"
+      ],
+      "nativeName": [
+        "සිංහල"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "LKA"
+      ]
+    },
+    {
+      "iso639_1": "sk",
+      "iso639_2": "slk",
+      "iso639_2en": "slo",
+      "iso639_3": "slk",
+      "name": [
+        "Slovak"
+      ],
+      "nativeName": [
+        "slovenčina",
+        "slovenský jazyk"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "SVK",
+        "CZE"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "sk-SK",
+          "displayName": "Slovak - Slovakia",
+          "cultureCode": "0x041B"
+        }
+      ]
+    },
+    {
+      "iso639_1": "sl",
+      "iso639_2": "slv",
+      "iso639_2en": "slv",
+      "iso639_3": "slv",
+      "name": [
+        "Slovene"
+      ],
+      "nativeName": [
+        "slovenski jezik",
+        "slovenščina"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "SVN"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "sl-SI",
+          "displayName": "Slovenian - Slovenia",
+          "cultureCode": "0x0424"
+        }
+      ]
+    },
+    {
+      "iso639_1": "so",
+      "iso639_2": "som",
+      "iso639_2en": "som",
+      "iso639_3": "som",
+      "name": [
+        "Somali"
+      ],
+      "nativeName": [
+        "Soomaaliga",
+        "af Soomaali"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "DJI",
+        "SOM"
+      ]
+    },
+    {
+      "iso639_1": "st",
+      "iso639_2": "sot",
+      "iso639_2en": "sot",
+      "iso639_3": "sot",
+      "name": [
+        "Southern Sotho"
+      ],
+      "nativeName": [
+        "Sesotho"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "LSO",
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "es",
+      "iso639_2": "spa",
+      "iso639_2en": "spa",
+      "iso639_3": "spa",
+      "name": [
+        "Spanish",
+        "Castilian"
+      ],
+      "nativeName": [
+        "español",
+        "castellano"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "ARG",
+        "BOL",
+        "CHL",
+        "COL",
+        "CRI",
+        "CUB",
+        "DOM",
+        "ECU",
+        "SLV",
+        "GNQ",
+        "GTM",
+        "HND",
+        "MEX",
+        "NIC",
+        "PAN",
+        "PRY",
+        "PER",
+        "PRI",
+        "ESP",
+        "URY",
+        "VEN",
+        "ESH"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "es-AR",
+          "displayName": "Spanish - Argentina",
+          "cultureCode": "0x2C0A"
+        },
+        {
+          "langCultureName": "es-BO",
+          "displayName": "Spanish - Bolivia",
+          "cultureCode": "0x400A"
+        },
+        {
+          "langCultureName": "es-CL",
+          "displayName": "Spanish - Chile",
+          "cultureCode": "0x340A"
+        },
+        {
+          "langCultureName": "es-CO",
+          "displayName": "Spanish - Colombia",
+          "cultureCode": "0x240A"
+        },
+        {
+          "langCultureName": "es-CR",
+          "displayName": "Spanish - Costa Rica",
+          "cultureCode": "0x140A"
+        },
+        {
+          "langCultureName": "es-DO",
+          "displayName": "Spanish - Dominican Republic",
+          "cultureCode": "0x1C0A"
+        },
+        {
+          "langCultureName": "es-EC",
+          "displayName": "Spanish - Ecuador",
+          "cultureCode": "0x300A"
+        },
+        {
+          "langCultureName": "es-SV",
+          "displayName": "Spanish - El Salvador",
+          "cultureCode": "0x440A"
+        },
+        {
+          "langCultureName": "es-GT",
+          "displayName": "Spanish - Guatemala",
+          "cultureCode": "0x100A"
+        },
+        {
+          "langCultureName": "es-HN",
+          "displayName": "Spanish - Honduras",
+          "cultureCode": "0x480A"
+        },
+        {
+          "langCultureName": "es-MX",
+          "displayName": "Spanish - Mexico",
+          "cultureCode": "0x080A"
+        },
+        {
+          "langCultureName": "es-NI",
+          "displayName": "Spanish - Nicaragua",
+          "cultureCode": "0x4C0A"
+        },
+        {
+          "langCultureName": "es-PA",
+          "displayName": "Spanish - Panama",
+          "cultureCode": "0x180A"
+        },
+        {
+          "langCultureName": "es-PY",
+          "displayName": "Spanish - Paraguay",
+          "cultureCode": "0x3C0A"
+        },
+        {
+          "langCultureName": "es-PE",
+          "displayName": "Spanish - Peru",
+          "cultureCode": "0x280A"
+        },
+        {
+          "langCultureName": "es-PR",
+          "displayName": "Spanish - Puerto Rico",
+          "cultureCode": "0x500A"
+        },
+        {
+          "langCultureName": "es-ES",
+          "displayName": "Spanish - Spain",
+          "cultureCode": "0x0C0A"
+        },
+        {
+          "langCultureName": "es-UY",
+          "displayName": "Spanish - Uruguay",
+          "cultureCode": "0x380A"
+        },
+        {
+          "langCultureName": "es-VE",
+          "displayName": "Spanish - Venezuela",
+          "cultureCode": "0x200A"
+        }
+      ]
+    },
+    {
+      "iso639_1": "su",
+      "iso639_2": "sun",
+      "iso639_2en": "sun",
+      "iso639_3": "sun",
+      "name": [
+        "Sundanese"
+      ],
+      "nativeName": [
+        "Basa Sunda"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian"
+    },
+    {
+      "iso639_1": "sw",
+      "iso639_2": "swa",
+      "iso639_2en": "swa",
+      "iso639_3": "swa",
+      "name": [
+        "Swahili"
+      ],
+      "nativeName": [
+        "Kiswahili"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "COD",
+        "KEN",
+        "TZA",
+        "UGA"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "sw-KE",
+          "displayName": "Swahili - Kenya",
+          "cultureCode": "0x0441"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ss",
+      "iso639_2": "ssw",
+      "iso639_2en": "ssw",
+      "iso639_3": "ssw",
+      "name": [
+        "Swati"
+      ],
+      "nativeName": [
+        "SiSwati"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "SWZ",
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "sv",
+      "iso639_2": "swe",
+      "iso639_2en": "swe",
+      "iso639_3": "swe",
+      "name": [
+        "Swedish"
+      ],
+      "nativeName": [
+        "Svenska"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "SWE",
+        "FIN",
+        "ALA"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "sv-FI",
+          "displayName": "Swedish - Finland",
+          "cultureCode": "0x081D"
+        },
+        {
+          "langCultureName": "sv-SE",
+          "displayName": "Swedish - Sweden",
+          "cultureCode": "0x041D"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ta",
+      "iso639_2": "tam",
+      "iso639_2en": "tam",
+      "iso639_3": "tam",
+      "name": [
+        "Tamil"
+      ],
+      "nativeName": [
+        "தமிழ்"
+      ],
+      "direction": "LTR",
+      "family": "Dravidian",
+      "countries": [
+        "IND",
+        "SGP",
+        "LKA",
+        "MYS",
+        "MUS"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ta-IN",
+          "displayName": "Tamil - India",
+          "cultureCode": "0x0449"
+        }
+      ]
+    },
+    {
+      "iso639_1": "te",
+      "iso639_2": "tel",
+      "iso639_2en": "tel",
+      "iso639_3": "tel",
+      "name": [
+        "Telugu"
+      ],
+      "nativeName": [
+        "తెలుగు"
+      ],
+      "direction": "LTR",
+      "family": "Dravidian",
+      "countries": [
+        "IND"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "te-IN",
+          "displayName": "Telugu - India",
+          "cultureCode": "0x044A"
+        }
+      ]
+    },
+    {
+      "iso639_1": "tg",
+      "iso639_2": "tgk",
+      "iso639_2en": "tgk",
+      "iso639_3": "tgk",
+      "name": [
+        "Tajik"
+      ],
+      "nativeName": [
+        "тоҷикӣ",
+        "toğikī",
+        "تاجیکی‎"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "TJK"
+      ]
+    },
+    {
+      "iso639_1": "th",
+      "iso639_2": "tha",
+      "iso639_2en": "tha",
+      "iso639_3": "tha",
+      "name": [
+        "Thai"
+      ],
+      "nativeName": [
+        "ไทย"
+      ],
+      "direction": "LTR",
+      "family": "Tai–Kadai",
+      "countries": [
+        "THA"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "th-TH",
+          "displayName": "Thai - Thailand",
+          "cultureCode": "0x041E"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ti",
+      "iso639_2": "tir",
+      "iso639_2en": "tir",
+      "iso639_3": "tir",
+      "name": [
+        "Tigrinya"
+      ],
+      "nativeName": [
+        "ትግርኛ"
+      ],
+      "direction": "LTR",
+      "family": "Afro-Asiatic",
+      "countries": [
+        "ERI"
+      ]
+    },
+    {
+      "iso639_1": "bo",
+      "iso639_2": "bod",
+      "iso639_2en": "tib",
+      "iso639_3": "bod",
+      "name": [
+        "Tibetan Standard",
+        "Tibetan",
+        "Central"
+      ],
+      "nativeName": [
+        "བོད་ཡིག"
+      ],
+      "direction": "LTR",
+      "family": "Sino-Tibetan"
+    },
+    {
+      "iso639_1": "tk",
+      "iso639_2": "tuk",
+      "iso639_2en": "tuk",
+      "iso639_3": "tuk",
+      "name": [
+        "Turkmen"
+      ],
+      "nativeName": [
+        "Türkmen",
+        "Түркмен"
+      ],
+      "direction": "LTR",
+      "family": "Turkic",
+      "countries": [
+        "TKM"
+      ]
+    },
+    {
+      "iso639_1": "tl",
+      "iso639_2": "tgl",
+      "iso639_2en": "tgl",
+      "iso639_3": "tgl",
+      "name": [
+        "Tagalog"
+      ],
+      "nativeName": [
+        "Wikang Tagalog"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "PHL"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "fil",
+      "iso639_2en": "fil",
+      "iso639_3": "fil",
+      "name": [
+        "Filipino"
+      ],
+      "nativeName": [
+        "Filipino"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian",
+      "countries": [
+        "PHL"
+      ]
+    },
+    {
+      "iso639_1": "tn",
+      "iso639_2": "tsn",
+      "iso639_2en": "tsn",
+      "iso639_3": "tsn",
+      "name": [
+        "Tswana"
+      ],
+      "nativeName": [
+        "Setswana"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "BWA",
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "to",
+      "iso639_2": "ton",
+      "iso639_2en": "ton",
+      "iso639_3": "ton",
+      "name": [
+        "Tonga (Tonga Islands)"
+      ],
+      "nativeName": [
+        "faka Tonga"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian"
+    },
+    {
+      "iso639_1": "tr",
+      "iso639_2": "tur",
+      "iso639_2en": "tur",
+      "iso639_3": "tur",
+      "name": [
+        "Turkish"
+      ],
+      "nativeName": [
+        "Türkçe"
+      ],
+      "direction": "LTR",
+      "family": "Turkic",
+      "countries": [
+        "TUR",
+        "CYP"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "tr-TR",
+          "displayName": "Turkish - Turkey",
+          "cultureCode": "0x041F"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ts",
+      "iso639_2": "tso",
+      "iso639_2en": "tso",
+      "iso639_3": "tso",
+      "name": [
+        "Tsonga"
+      ],
+      "nativeName": [
+        "Xitsonga"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "tt",
+      "iso639_2": "tat",
+      "iso639_2en": "tat",
+      "iso639_3": "tat",
+      "name": [
+        "Tatar"
+      ],
+      "nativeName": [
+        "татар теле",
+        "tatar tele"
+      ],
+      "direction": "LTR",
+      "family": "Turkic",
+      "langCultureMs": [
+        {
+          "langCultureName": "tt-RU",
+          "displayName": "Tatar - Russia",
+          "cultureCode": "0x0444"
+        }
+      ]
+    },
+    {
+      "iso639_1": "tw",
+      "iso639_2": "twi",
+      "iso639_2en": "twi",
+      "iso639_3": "twi",
+      "name": [
+        "Twi"
+      ],
+      "nativeName": [
+        "Twi"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo"
+    },
+    {
+      "iso639_1": "ty",
+      "iso639_2": "tah",
+      "iso639_2en": "tah",
+      "iso639_3": "tah",
+      "name": [
+        "Tahitian"
+      ],
+      "nativeName": [
+        "Reo Tahiti"
+      ],
+      "direction": "LTR",
+      "family": "Austronesian"
+    },
+    {
+      "iso639_1": "ug",
+      "iso639_2": "uig",
+      "iso639_2en": "uig",
+      "iso639_3": "uig",
+      "name": [
+        "Uyghur",
+        "Uighur"
+      ],
+      "nativeName": [
+        "Uyƣurqə",
+        "ئۇيغۇرچە‎"
+      ],
+      "direction": "RTL",
+      "family": "Turkic"
+    },
+    {
+      "iso639_1": "uk",
+      "iso639_2": "ukr",
+      "iso639_2en": "ukr",
+      "iso639_3": "ukr",
+      "name": [
+        "Ukrainian"
+      ],
+      "nativeName": [
+        "українська мова"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "UKR"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "uk-UA",
+          "displayName": "Ukrainian - Ukraine",
+          "cultureCode": "0x0422"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ur",
+      "iso639_2": "urd",
+      "iso639_2en": "urd",
+      "iso639_3": "urd",
+      "name": [
+        "Urdu"
+      ],
+      "nativeName": [
+        "اردو"
+      ],
+      "direction": "RTL",
+      "family": "Indo-European",
+      "countries": [
+        "PAK",
+        "FJI"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "ur-PK",
+          "displayName": "Urdu - Pakistan",
+          "cultureCode": "0x0420"
+        }
+      ]
+    },
+    {
+      "iso639_1": "uz",
+      "iso639_2": "uzb",
+      "iso639_2en": "uzb",
+      "iso639_3": "uzb",
+      "name": [
+        "Uzbek"
+      ],
+      "nativeName": [
+        "O‘zbek",
+        "Ўзбек",
+        "أۇزبېك‎"
+      ],
+      "direction": "LTR",
+      "family": "Turkic",
+      "countries": [
+        "UZB"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "Cy-uz-UZ",
+          "displayName": "Uzbek (Cyrillic) - Uzbekistan",
+          "cultureCode": "0x0843"
+        },
+        {
+          "langCultureName": "Lt-uz-UZ",
+          "displayName": "Uzbek (Latin) - Uzbekistan",
+          "cultureCode": "0x0443"
+        }
+      ]
+    },
+    {
+      "iso639_1": "ve",
+      "iso639_2": "ven",
+      "iso639_2en": "ven",
+      "iso639_3": "ven",
+      "name": [
+        "Venda"
+      ],
+      "nativeName": [
+        "Tshivenḓa"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "vi",
+      "iso639_2": "vie",
+      "iso639_2en": "vie",
+      "iso639_3": "vie",
+      "name": [
+        "Vietnamese"
+      ],
+      "nativeName": [
+        "Tiếng Việt"
+      ],
+      "direction": "LTR",
+      "family": "Austroasiatic",
+      "countries": [
+        "VNM"
+      ],
+      "langCultureMs": [
+        {
+          "langCultureName": "vi-VN",
+          "displayName": "Vietnamese - Vietnam",
+          "cultureCode": "0x042A"
+        }
+      ]
+    },
+    {
+      "iso639_1": "vo",
+      "iso639_2": "vol",
+      "iso639_2en": "vol",
+      "iso639_3": "vol",
+      "name": [
+        "Volapük"
+      ],
+      "nativeName": [
+        "Volapük"
+      ],
+      "direction": "LTR",
+      "family": "Constructed"
+    },
+    {
+      "iso639_1": "wa",
+      "iso639_2": "wln",
+      "iso639_2en": "wln",
+      "iso639_3": "wln",
+      "name": [
+        "Walloon"
+      ],
+      "nativeName": [
+        "walon"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "cy",
+      "iso639_2": "cym",
+      "iso639_2en": "wel",
+      "iso639_3": "cym",
+      "name": [
+        "Welsh"
+      ],
+      "nativeName": [
+        "Cymraeg"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European",
+      "countries": [
+        "GBR"
+      ]
+    },
+    {
+      "iso639_1": "wo",
+      "iso639_2": "wol",
+      "iso639_2en": "wol",
+      "iso639_3": "wol",
+      "name": [
+        "Wolof"
+      ],
+      "nativeName": [
+        "Wollof"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "SEN"
+      ]
+    },
+    {
+      "iso639_1": "fy",
+      "iso639_2": "fry",
+      "iso639_2en": "fry",
+      "iso639_3": "fry",
+      "name": [
+        "Western Frisian"
+      ],
+      "nativeName": [
+        "Frysk"
+      ],
+      "direction": "LTR",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "xh",
+      "iso639_2": "xho",
+      "iso639_2en": "xho",
+      "iso639_3": "xho",
+      "name": [
+        "Xhosa"
+      ],
+      "nativeName": [
+        "isiXhosa"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "yi",
+      "iso639_2": "yid",
+      "iso639_2en": "yid",
+      "iso639_3": "yid",
+      "name": [
+        "Yiddish"
+      ],
+      "nativeName": [
+        "ייִדיש"
+      ],
+      "direction": "RTL",
+      "family": "Indo-European"
+    },
+    {
+      "iso639_1": "yo",
+      "iso639_2": "yor",
+      "iso639_2en": "yor",
+      "iso639_3": "yor",
+      "name": [
+        "Yoruba"
+      ],
+      "nativeName": [
+        "Yorùbá"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "BEN",
+        "NGA"
+      ]
+    },
+    {
+      "iso639_1": "za",
+      "iso639_2": "zha",
+      "iso639_2en": "zha",
+      "iso639_3": "zha",
+      "name": [
+        "Zhuang",
+        "Chuang"
+      ],
+      "nativeName": [
+        "Saɯ cueŋƅ",
+        "Saw cuengh"
+      ],
+      "direction": "LTR",
+      "family": "Tai–Kadai"
+    },
+    {
+      "iso639_1": "zu",
+      "iso639_2": "zul",
+      "iso639_2en": "zul",
+      "iso639_3": "zul",
+      "name": [
+        "Zulu"
+      ],
+      "nativeName": [
+        "isiZulu"
+      ],
+      "direction": "LTR",
+      "family": "Niger–Congo",
+      "countries": [
+        "ZAF"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ace",
+      "iso639_2en": "ace",
+      "iso639_3": "ace",
+      "name": [
+        "Achinese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ach",
+      "iso639_2en": "ach",
+      "iso639_3": "ach",
+      "name": [
+        "Acoli"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ada",
+      "iso639_2en": "ada",
+      "iso639_3": "ada",
+      "name": [
+        "Adangme"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ady",
+      "iso639_2en": "ady",
+      "iso639_3": "ady",
+      "name": [
+        "Adyghe",
+        " Adygei"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "afa",
+      "iso639_2en": "afa",
+      "iso639_3": "afa",
+      "name": [
+        "Afro-Asiatic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "afh",
+      "iso639_2en": "afh",
+      "iso639_3": "afh",
+      "name": [
+        "Afrihili"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ain",
+      "iso639_2en": "ain",
+      "iso639_3": "ain",
+      "name": [
+        "Ainu"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "akk",
+      "iso639_2en": "akk",
+      "iso639_3": "akk",
+      "name": [
+        "Akkadian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ale",
+      "iso639_2en": "ale",
+      "iso639_3": "ale",
+      "name": [
+        "Aleut"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "alg",
+      "iso639_2en": "alg",
+      "iso639_3": "alg",
+      "name": [
+        "Algonquian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "alt",
+      "iso639_2en": "alt",
+      "iso639_3": "alt",
+      "name": [
+        "Southern Altai"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ang",
+      "iso639_2en": "ang",
+      "iso639_3": "ang",
+      "name": [
+        "English, Old (ca.450-1100)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "anp",
+      "iso639_2en": "anp",
+      "iso639_3": "anp",
+      "name": [
+        "Angika"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "apa",
+      "iso639_2en": "apa",
+      "iso639_3": "apa",
+      "name": [
+        "Apache languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "arc",
+      "iso639_2en": "arc",
+      "iso639_3": "arc",
+      "name": [
+        "Official Aramaic (700-300 BCE)",
+        " Imperial Aramaic (700-300 BCE)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "RTL",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "arn",
+      "iso639_2en": "arn",
+      "iso639_3": "arn",
+      "name": [
+        "Mapudungun",
+        " Mapuche"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "arp",
+      "iso639_2en": "arp",
+      "iso639_3": "arp",
+      "name": [
+        "Arapaho"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "art",
+      "iso639_2en": "art",
+      "iso639_3": "art",
+      "name": [
+        "Artificial languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "arw",
+      "iso639_2en": "arw",
+      "iso639_3": "arw",
+      "name": [
+        "Arawak"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ast",
+      "iso639_2en": "ast",
+      "iso639_3": "ast",
+      "name": [
+        "Asturian",
+        " Bable",
+        " Leonese",
+        " Asturleonese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ath",
+      "iso639_2en": "ath",
+      "iso639_3": "ath",
+      "name": [
+        "Athapascan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "aus",
+      "iso639_2en": "aus",
+      "iso639_3": "aus",
+      "name": [
+        "Australian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "awa",
+      "iso639_2en": "awa",
+      "iso639_3": "awa",
+      "name": [
+        "Awadhi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bad",
+      "iso639_2en": "bad",
+      "iso639_3": "bad",
+      "name": [
+        "Banda languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bai",
+      "iso639_2en": "bai",
+      "iso639_3": "bai",
+      "name": [
+        "Bamileke languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bal",
+      "iso639_2en": "bal",
+      "iso639_3": "bal",
+      "name": [
+        "Baluchi",
+        "Balochi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "RTL",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ban",
+      "iso639_2en": "ban",
+      "iso639_3": "ban",
+      "name": [
+        "Balinese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bas",
+      "iso639_2en": "bas",
+      "iso639_3": "bas",
+      "name": [
+        "Basa"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bat",
+      "iso639_2en": "bat",
+      "iso639_3": "bat",
+      "name": [
+        "Baltic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bej",
+      "iso639_2en": "bej",
+      "iso639_3": "bej",
+      "name": [
+        "Beja",
+        " Bedawiyet"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bem",
+      "iso639_2en": "bem",
+      "iso639_3": "bem",
+      "name": [
+        "Bemba"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bho",
+      "iso639_2en": "bho",
+      "iso639_3": "bho",
+      "name": [
+        "Bhojpuri"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bik",
+      "iso639_2en": "bik",
+      "iso639_3": "bik",
+      "name": [
+        "Bikol"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bin",
+      "iso639_2en": "bin",
+      "iso639_3": "bin",
+      "name": [
+        "Bini",
+        " Edo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bla",
+      "iso639_2en": "bla",
+      "iso639_3": "bla",
+      "name": [
+        "Siksika"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bnt",
+      "iso639_2en": "bnt",
+      "iso639_3": "bnt",
+      "name": [
+        "Bantu languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bra",
+      "iso639_2en": "bra",
+      "iso639_3": "bra",
+      "name": [
+        "Braj"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "btk",
+      "iso639_2en": "btk",
+      "iso639_3": "btk",
+      "name": [
+        "Batak languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bua",
+      "iso639_2en": "bua",
+      "iso639_3": "bua",
+      "name": [
+        "Buriat"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "bug",
+      "iso639_2en": "bug",
+      "iso639_3": "bug",
+      "name": [
+        "Buginese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "byn",
+      "iso639_2en": "byn",
+      "iso639_3": "byn",
+      "name": [
+        "Blin",
+        " Bilin"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cad",
+      "iso639_2en": "cad",
+      "iso639_3": "cad",
+      "name": [
+        "Caddo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cai",
+      "iso639_2en": "cai",
+      "iso639_3": "cai",
+      "name": [
+        "Central American Indian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "car",
+      "iso639_2en": "car",
+      "iso639_3": "car",
+      "name": [
+        "Galibi Carib"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cau",
+      "iso639_2en": "cau",
+      "iso639_3": "cau",
+      "name": [
+        "Caucasian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ceb",
+      "iso639_2en": "ceb",
+      "iso639_3": "ceb",
+      "name": [
+        "Cebuano"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cel",
+      "iso639_2en": "cel",
+      "iso639_3": "cel",
+      "name": [
+        "Celtic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chb",
+      "iso639_2en": "chb",
+      "iso639_3": "chb",
+      "name": [
+        "Chibcha"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chg",
+      "iso639_2en": "chg",
+      "iso639_3": "chg",
+      "name": [
+        "Chagatai"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chk",
+      "iso639_2en": "chk",
+      "iso639_3": "chk",
+      "name": [
+        "Chuukese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chm",
+      "iso639_2en": "chm",
+      "iso639_3": "chm",
+      "name": [
+        "Mari"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chn",
+      "iso639_2en": "chn",
+      "iso639_3": "chn",
+      "name": [
+        "Chinook jargon"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cho",
+      "iso639_2en": "cho",
+      "iso639_3": "cho",
+      "name": [
+        "Choctaw"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chp",
+      "iso639_2en": "chp",
+      "iso639_3": "chp",
+      "name": [
+        "Chipewyan",
+        " Dene Suline"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chr",
+      "iso639_2en": "chr",
+      "iso639_3": "chr",
+      "name": [
+        "Cherokee"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "chy",
+      "iso639_2en": "chy",
+      "iso639_3": "chy",
+      "name": [
+        "Cheyenne"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cmc",
+      "iso639_2en": "cmc",
+      "iso639_3": "cmc",
+      "name": [
+        "Chamic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cop",
+      "iso639_2en": "cop",
+      "iso639_3": "cop",
+      "name": [
+        "Coptic"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cpe",
+      "iso639_2en": "cpe",
+      "iso639_3": "cpe",
+      "name": [
+        "Creoles and pidgins, English based"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cpf",
+      "iso639_2en": "cpf",
+      "iso639_3": "cpf",
+      "name": [
+        "Creoles and pidgins, French-based"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cpp",
+      "iso639_2en": "cpp",
+      "iso639_3": "cpp",
+      "name": [
+        "Creoles and pidgins, Portuguese-based"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "crh",
+      "iso639_2en": "crh",
+      "iso639_3": "crh",
+      "name": [
+        "Crimean Tatar",
+        " Crimean Turkish"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "crp",
+      "iso639_2en": "crp",
+      "iso639_3": "crp",
+      "name": [
+        "Creoles and pidgins"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "csb",
+      "iso639_2en": "csb",
+      "iso639_3": "csb",
+      "name": [
+        "Kashubian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "cus",
+      "iso639_2en": "cus",
+      "iso639_3": "cus",
+      "name": [
+        "Cushitic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dak",
+      "iso639_2en": "dak",
+      "iso639_3": "dak",
+      "name": [
+        "Dakota"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dar",
+      "iso639_2en": "dar",
+      "iso639_3": "dar",
+      "name": [
+        "Dargwa"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "day",
+      "iso639_2en": "day",
+      "iso639_3": "day",
+      "name": [
+        "Land Dayak languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "del",
+      "iso639_2en": "del",
+      "iso639_3": "del",
+      "name": [
+        "Delaware"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "den",
+      "iso639_2en": "den",
+      "iso639_3": "den",
+      "name": [
+        "Slave (Athapascan)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dgr",
+      "iso639_2en": "dgr",
+      "iso639_3": "dgr",
+      "name": [
+        "Dogrib"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "din",
+      "iso639_2en": "din",
+      "iso639_3": "din",
+      "name": [
+        "Dinka"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "doi",
+      "iso639_2en": "doi",
+      "iso639_3": "doi",
+      "name": [
+        "Dogri"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dra",
+      "iso639_2en": "dra",
+      "iso639_3": "dra",
+      "name": [
+        "Dravidian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dsb",
+      "iso639_2en": "dsb",
+      "iso639_3": "dsb",
+      "name": [
+        "Lower Sorbian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dua",
+      "iso639_2en": "dua",
+      "iso639_3": "dua",
+      "name": [
+        "Duala"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dum",
+      "iso639_2en": "dum",
+      "iso639_3": "dum",
+      "name": [
+        "Dutch, Middle (ca.1050-1350)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "dyu",
+      "iso639_2en": "dyu",
+      "iso639_3": "dyu",
+      "name": [
+        "Dyula"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "efi",
+      "iso639_2en": "efi",
+      "iso639_3": "efi",
+      "name": [
+        "Efik"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "egy",
+      "iso639_2en": "egy",
+      "iso639_3": "egy",
+      "name": [
+        "Egyptian (Ancient)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "eka",
+      "iso639_2en": "eka",
+      "iso639_3": "eka",
+      "name": [
+        "Ekajuk"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "elx",
+      "iso639_2en": "elx",
+      "iso639_3": "elx",
+      "name": [
+        "Elamite"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "enm",
+      "iso639_2en": "enm",
+      "iso639_3": "enm",
+      "name": [
+        "English, Middle (1100-1500)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ewo",
+      "iso639_2en": "ewo",
+      "iso639_3": "ewo",
+      "name": [
+        "Ewondo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "fan",
+      "iso639_2en": "fan",
+      "iso639_3": "fan",
+      "name": [
+        "Fang"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "fat",
+      "iso639_2en": "fat",
+      "iso639_3": "fat",
+      "name": [
+        "Fanti"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "fiu",
+      "iso639_2en": "fiu",
+      "iso639_3": "fiu",
+      "name": [
+        "Finno-Ugrian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "fon",
+      "iso639_2en": "fon",
+      "iso639_3": "fon",
+      "name": [
+        "Fon"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "frm",
+      "iso639_2en": "frm",
+      "iso639_3": "frm",
+      "name": [
+        "French, Middle (ca.1400-1600)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "fro",
+      "iso639_2en": "fro",
+      "iso639_3": "fro",
+      "name": [
+        "French, Old (842-ca.1400)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "frr",
+      "iso639_2en": "frr",
+      "iso639_3": "frr",
+      "name": [
+        "Northern Frisian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "frs",
+      "iso639_2en": "frs",
+      "iso639_3": "frs",
+      "name": [
+        "Eastern Frisian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "fur",
+      "iso639_2en": "fur",
+      "iso639_3": "fur",
+      "name": [
+        "Friulian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gaa",
+      "iso639_2en": "gaa",
+      "iso639_3": "gaa",
+      "name": [
+        "Ga"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "GHA"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gay",
+      "iso639_2en": "gay",
+      "iso639_3": "gay",
+      "name": [
+        "Gayo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gba",
+      "iso639_2en": "gba",
+      "iso639_3": "gba",
+      "name": [
+        "Gbaya"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gem",
+      "iso639_2en": "gem",
+      "iso639_3": "gem",
+      "name": [
+        "Germanic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gez",
+      "iso639_2en": "gez",
+      "iso639_3": "gez",
+      "name": [
+        "Geez"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gil",
+      "iso639_2en": "gil",
+      "iso639_3": "gil",
+      "name": [
+        "Gilbertese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gmh",
+      "iso639_2en": "gmh",
+      "iso639_3": "gmh",
+      "name": [
+        "German, Middle High (ca.1050-1500)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "goh",
+      "iso639_2en": "goh",
+      "iso639_3": "goh",
+      "name": [
+        "German, Old High (ca.750-1050)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gon",
+      "iso639_2en": "gon",
+      "iso639_3": "gon",
+      "name": [
+        "Gondi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gor",
+      "iso639_2en": "gor",
+      "iso639_3": "gor",
+      "name": [
+        "Gorontalo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "got",
+      "iso639_2en": "got",
+      "iso639_3": "got",
+      "name": [
+        "Gothic"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "grb",
+      "iso639_2en": "grb",
+      "iso639_3": "grb",
+      "name": [
+        "Grebo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "grc",
+      "iso639_2en": "grc",
+      "iso639_3": "grc",
+      "name": [
+        "Greek, Ancient (to 1453)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gsw",
+      "iso639_2en": "gsw",
+      "iso639_3": "gsw",
+      "name": [
+        "Swiss German",
+        " Alemannic",
+        " Alsatian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "gwi",
+      "iso639_2en": "gwi",
+      "iso639_3": "gwi",
+      "name": [
+        "Gwich'in"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "hai",
+      "iso639_2en": "hai",
+      "iso639_3": "hai",
+      "name": [
+        "Haida"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "haw",
+      "iso639_2en": "haw",
+      "iso639_3": "haw",
+      "name": [
+        "Hawaiian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "hil",
+      "iso639_2en": "hil",
+      "iso639_3": "hil",
+      "name": [
+        "Hiligaynon"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "him",
+      "iso639_2en": "him",
+      "iso639_3": "him",
+      "name": [
+        "Himachali languages",
+        " Western Pahari languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "hit",
+      "iso639_2en": "hit",
+      "iso639_3": "hit",
+      "name": [
+        "Hittite"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "hmn",
+      "iso639_2en": "hmn",
+      "iso639_3": "hmn",
+      "name": [
+        "Hmong",
+        " Mong"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "hsb",
+      "iso639_2en": "hsb",
+      "iso639_3": "hsb",
+      "name": [
+        "Upper Sorbian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "hup",
+      "iso639_2en": "hup",
+      "iso639_3": "hup",
+      "name": [
+        "Hupa"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "iba",
+      "iso639_2en": "iba",
+      "iso639_3": "iba",
+      "name": [
+        "Iban"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ijo",
+      "iso639_2en": "ijo",
+      "iso639_3": "ijo",
+      "name": [
+        "Ijo languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ilo",
+      "iso639_2en": "ilo",
+      "iso639_3": "ilo",
+      "name": [
+        "Iloko"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "inc",
+      "iso639_2en": "inc",
+      "iso639_3": "inc",
+      "name": [
+        "Indic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ine",
+      "iso639_2en": "ine",
+      "iso639_3": "ine",
+      "name": [
+        "Indo-European languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "inh",
+      "iso639_2en": "inh",
+      "iso639_3": "inh",
+      "name": [
+        "Ingush"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ira",
+      "iso639_2en": "ira",
+      "iso639_3": "ira",
+      "name": [
+        "Iranian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "iro",
+      "iso639_2en": "iro",
+      "iso639_3": "iro",
+      "name": [
+        "Iroquoian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "jbo",
+      "iso639_2en": "jbo",
+      "iso639_3": "jbo",
+      "name": [
+        "Lojban"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "jpr",
+      "iso639_2en": "jpr",
+      "iso639_3": "jpr",
+      "name": [
+        "Judeo-Persian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "jrb",
+      "iso639_2en": "jrb",
+      "iso639_3": "jrb",
+      "name": [
+        "Judeo-Arabic"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kaa",
+      "iso639_2en": "kaa",
+      "iso639_3": "kaa",
+      "name": [
+        "Kara-Kalpak"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kab",
+      "iso639_2en": "kab",
+      "iso639_3": "kab",
+      "name": [
+        "Kabyle"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kac",
+      "iso639_2en": "kac",
+      "iso639_3": "kac",
+      "name": [
+        "Kachin",
+        " Jingpho"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kam",
+      "iso639_2en": "kam",
+      "iso639_3": "kam",
+      "name": [
+        "Kamba"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kar",
+      "iso639_2en": "kar",
+      "iso639_3": "kar",
+      "name": [
+        "Karen languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kaw",
+      "iso639_2en": "kaw",
+      "iso639_3": "kaw",
+      "name": [
+        "Kawi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kbd",
+      "iso639_2en": "kbd",
+      "iso639_3": "kbd",
+      "name": [
+        "Kabardian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kha",
+      "iso639_2en": "kha",
+      "iso639_3": "kha",
+      "name": [
+        "Khasi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "khi",
+      "iso639_2en": "khi",
+      "iso639_3": "khi",
+      "name": [
+        "Khoisan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kho",
+      "iso639_2en": "kho",
+      "iso639_3": "kho",
+      "name": [
+        "Khotanese",
+        " Sakan"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kmb",
+      "iso639_2en": "kmb",
+      "iso639_3": "kmb",
+      "name": [
+        "Kimbundu"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "AGO"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kok",
+      "iso639_2en": "kok",
+      "iso639_3": "kok",
+      "name": [
+        "Konkani"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "langCultureMs": [
+        {
+          "langCultureName": "kok-IN",
+          "displayName": "Konkani - India",
+          "cultureCode": "0x0457"
+        }
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kos",
+      "iso639_2en": "kos",
+      "iso639_3": "kos",
+      "name": [
+        "Kosraean"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kpe",
+      "iso639_2en": "kpe",
+      "iso639_3": "kpe",
+      "name": [
+        "Kpelle"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "krc",
+      "iso639_2en": "krc",
+      "iso639_3": "krc",
+      "name": [
+        "Karachay-Balkar"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "krl",
+      "iso639_2en": "krl",
+      "iso639_3": "krl",
+      "name": [
+        "Karelian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kro",
+      "iso639_2en": "kro",
+      "iso639_3": "kro",
+      "name": [
+        "Kru languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kru",
+      "iso639_2en": "kru",
+      "iso639_3": "kru",
+      "name": [
+        "Kurukh"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kum",
+      "iso639_2en": "kum",
+      "iso639_3": "kum",
+      "name": [
+        "Kumyk"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "kut",
+      "iso639_2en": "kut",
+      "iso639_3": "kut",
+      "name": [
+        "Kutenai"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lad",
+      "iso639_2en": "lad",
+      "iso639_3": "lad",
+      "name": [
+        "Ladino"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lah",
+      "iso639_2en": "lah",
+      "iso639_3": "lah",
+      "name": [
+        "Lahnda"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lam",
+      "iso639_2en": "lam",
+      "iso639_3": "lam",
+      "name": [
+        "Lamba"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lez",
+      "iso639_2en": "lez",
+      "iso639_3": "lez",
+      "name": [
+        "Lezghian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lol",
+      "iso639_2en": "lol",
+      "iso639_3": "lol",
+      "name": [
+        "Mongo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "loz",
+      "iso639_2en": "loz",
+      "iso639_3": "loz",
+      "name": [
+        "Lozi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lua",
+      "iso639_2en": "lua",
+      "iso639_3": "lua",
+      "name": [
+        "Luba-Lulua"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lui",
+      "iso639_2en": "lui",
+      "iso639_3": "lui",
+      "name": [
+        "Luiseno"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lun",
+      "iso639_2en": "lun",
+      "iso639_3": "lun",
+      "name": [
+        "Lunda"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "luo",
+      "iso639_2en": "luo",
+      "iso639_3": "luo",
+      "name": [
+        "Luo (Kenya and Tanzania)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "lus",
+      "iso639_2en": "lus",
+      "iso639_3": "lus",
+      "name": [
+        "Lushai"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mad",
+      "iso639_2en": "mad",
+      "iso639_3": "mad",
+      "name": [
+        "Madurese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mag",
+      "iso639_2en": "mag",
+      "iso639_3": "mag",
+      "name": [
+        "Magahi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mai",
+      "iso639_2en": "mai",
+      "iso639_3": "mai",
+      "name": [
+        "Maithili"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mak",
+      "iso639_2en": "mak",
+      "iso639_3": "mak",
+      "name": [
+        "Makasar"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "man",
+      "iso639_2en": "man",
+      "iso639_3": "man",
+      "name": [
+        "Mandingo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "map",
+      "iso639_2en": "map",
+      "iso639_3": "map",
+      "name": [
+        "Austronesian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mas",
+      "iso639_2en": "mas",
+      "iso639_3": "mas",
+      "name": [
+        "Masai"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mdf",
+      "iso639_2en": "mdf",
+      "iso639_3": "mdf",
+      "name": [
+        "Moksha"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mdr",
+      "iso639_2en": "mdr",
+      "iso639_3": "mdr",
+      "name": [
+        "Mandar"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "men",
+      "iso639_2en": "men",
+      "iso639_3": "men",
+      "name": [
+        "Mende"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mga",
+      "iso639_2en": "mga",
+      "iso639_3": "mga",
+      "name": [
+        "Irish, Middle (900-1200)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mic",
+      "iso639_2en": "mic",
+      "iso639_3": "mic",
+      "name": [
+        "Mi'kmaq",
+        " Micmac"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "min",
+      "iso639_2en": "min",
+      "iso639_3": "min",
+      "name": [
+        "Minangkabau"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mis",
+      "iso639_2en": "mis",
+      "iso639_3": "mis",
+      "name": [
+        "Uncoded languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mkh",
+      "iso639_2en": "mkh",
+      "iso639_3": "mkh",
+      "name": [
+        "Mon-Khmer languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mnc",
+      "iso639_2en": "mnc",
+      "iso639_3": "mnc",
+      "name": [
+        "Manchu"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mni",
+      "iso639_2en": "mni",
+      "iso639_3": "mni",
+      "name": [
+        "Manipuri"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mno",
+      "iso639_2en": "mno",
+      "iso639_3": "mno",
+      "name": [
+        "Manobo languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "moh",
+      "iso639_2en": "moh",
+      "iso639_3": "moh",
+      "name": [
+        "Mohawk"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mos",
+      "iso639_2en": "mos",
+      "iso639_3": "mos",
+      "name": [
+        "Mossi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "BFA"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mul",
+      "iso639_2en": "mul",
+      "iso639_3": "mul",
+      "name": [
+        "Multiple languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mun",
+      "iso639_2en": "mun",
+      "iso639_3": "mun",
+      "name": [
+        "Munda languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mus",
+      "iso639_2en": "mus",
+      "iso639_3": "mus",
+      "name": [
+        "Creek"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mwl",
+      "iso639_2en": "mwl",
+      "iso639_3": "mwl",
+      "name": [
+        "Mirandese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "mwr",
+      "iso639_2en": "mwr",
+      "iso639_3": "mwr",
+      "name": [
+        "Marwari"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "myn",
+      "iso639_2en": "myn",
+      "iso639_3": "myn",
+      "name": [
+        "Mayan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "myv",
+      "iso639_2en": "myv",
+      "iso639_3": "myv",
+      "name": [
+        "Erzya"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nah",
+      "iso639_2en": "nah",
+      "iso639_3": "nah",
+      "name": [
+        "Nahuatl languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nai",
+      "iso639_2en": "nai",
+      "iso639_3": "nai",
+      "name": [
+        "North American Indian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nap",
+      "iso639_2en": "nap",
+      "iso639_3": "nap",
+      "name": [
+        "Neapolitan"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nds",
+      "iso639_2en": "nds",
+      "iso639_3": "nds",
+      "name": [
+        "Low German",
+        " Low Saxon",
+        " German, Low",
+        " Saxon, Low"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "new",
+      "iso639_2en": "new",
+      "iso639_3": "new",
+      "name": [
+        "Nepal Bhasa",
+        " Newari"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nia",
+      "iso639_2en": "nia",
+      "iso639_3": "nia",
+      "name": [
+        "Nias"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nic",
+      "iso639_2en": "nic",
+      "iso639_3": "nic",
+      "name": [
+        "Niger-Kordofanian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "niu",
+      "iso639_2en": "niu",
+      "iso639_3": "niu",
+      "name": [
+        "Niuean"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nog",
+      "iso639_2en": "nog",
+      "iso639_3": "nog",
+      "name": [
+        "Nogai"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "non",
+      "iso639_2en": "non",
+      "iso639_3": "non",
+      "name": [
+        "Norse, Old"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nqo",
+      "iso639_2en": "nqo",
+      "iso639_3": "nqo",
+      "name": [
+        "N'Ko"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nub",
+      "iso639_2en": "nub",
+      "iso639_3": "nub",
+      "name": [
+        "Nubian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nwc",
+      "iso639_2en": "nwc",
+      "iso639_3": "nwc",
+      "name": [
+        "Classical Newari",
+        " Old Newari",
+        " Classical Nepal Bhasa"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nym",
+      "iso639_2en": "nym",
+      "iso639_3": "nym",
+      "name": [
+        "Nyamwezi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nyn",
+      "iso639_2en": "nyn",
+      "iso639_3": "nyn",
+      "name": [
+        "Nyankole"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nyo",
+      "iso639_2en": "nyo",
+      "iso639_3": "nyo",
+      "name": [
+        "Nyoro"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "nzi",
+      "iso639_2en": "nzi",
+      "iso639_3": "nzi",
+      "name": [
+        "Nzima"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "osa",
+      "iso639_2en": "osa",
+      "iso639_3": "osa",
+      "name": [
+        "Osage"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ota",
+      "iso639_2en": "ota",
+      "iso639_3": "ota",
+      "name": [
+        "Turkish, Ottoman (1500-1928)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "oto",
+      "iso639_2en": "oto",
+      "iso639_3": "oto",
+      "name": [
+        "Otomian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "paa",
+      "iso639_2en": "paa",
+      "iso639_3": "paa",
+      "name": [
+        "Papuan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pag",
+      "iso639_2en": "pag",
+      "iso639_3": "pag",
+      "name": [
+        "Pangasinan"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pal",
+      "iso639_2en": "pal",
+      "iso639_3": "pal",
+      "name": [
+        "Pahlavi"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pam",
+      "iso639_2en": "pam",
+      "iso639_3": "pam",
+      "name": [
+        "Pampanga",
+        " Kapampangan"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pap",
+      "iso639_2en": "pap",
+      "iso639_3": "pap",
+      "name": [
+        "Papiamento"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "ABW",
+        "CUW"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pau",
+      "iso639_2en": "pau",
+      "iso639_3": "pau",
+      "name": [
+        "Palauan"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "peo",
+      "iso639_2en": "peo",
+      "iso639_3": "peo",
+      "name": [
+        "Persian, Old (ca.600-400 B.C.)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "phi",
+      "iso639_2en": "phi",
+      "iso639_3": "phi",
+      "name": [
+        "Philippine languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "phn",
+      "iso639_2en": "phn",
+      "iso639_3": "phn",
+      "name": [
+        "Phoenician"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pon",
+      "iso639_2en": "pon",
+      "iso639_3": "pon",
+      "name": [
+        "Pohnpeian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pra",
+      "iso639_2en": "pra",
+      "iso639_3": "pra",
+      "name": [
+        "Prakrit languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "pro",
+      "iso639_2en": "pro",
+      "iso639_3": "pro",
+      "name": [
+        "Proven�al, Old (to 1500)",
+        "Occitan, Old (to 1500)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "qaa-qtz",
+      "iso639_2en": "qaa-qtz",
+      "iso639_3": "qaa-qtz",
+      "name": [
+        "Reserved for local use"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "raj",
+      "iso639_2en": "raj",
+      "iso639_3": "raj",
+      "name": [
+        "Rajasthani"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "rap",
+      "iso639_2en": "rap",
+      "iso639_3": "rap",
+      "name": [
+        "Rapanui"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "rar",
+      "iso639_2en": "rar",
+      "iso639_3": "rar",
+      "name": [
+        "Rarotongan",
+        " Cook Islands Maori"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "roa",
+      "iso639_2en": "roa",
+      "iso639_3": "roa",
+      "name": [
+        "Romance languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "rom",
+      "iso639_2en": "rom",
+      "iso639_3": "rom",
+      "name": [
+        "Romany"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "rup",
+      "iso639_2en": "rup",
+      "iso639_3": "rup",
+      "name": [
+        "Aromanian",
+        " Arumanian",
+        " Macedo-Romanian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sad",
+      "iso639_2en": "sad",
+      "iso639_3": "sad",
+      "name": [
+        "Sandawe"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sah",
+      "iso639_2en": "sah",
+      "iso639_3": "sah",
+      "name": [
+        "Yakut"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sai",
+      "iso639_2en": "sai",
+      "iso639_3": "sai",
+      "name": [
+        "South American Indian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sal",
+      "iso639_2en": "sal",
+      "iso639_3": "sal",
+      "name": [
+        "Salishan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sam",
+      "iso639_2en": "sam",
+      "iso639_3": "sam",
+      "name": [
+        "Samaritan Aramaic"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sas",
+      "iso639_2en": "sas",
+      "iso639_3": "sas",
+      "name": [
+        "Sasak"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sat",
+      "iso639_2en": "sat",
+      "iso639_3": "sat",
+      "name": [
+        "Santali"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "scn",
+      "iso639_2en": "scn",
+      "iso639_3": "scn",
+      "name": [
+        "Sicilian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sco",
+      "iso639_2en": "sco",
+      "iso639_3": "sco",
+      "name": [
+        "Scots"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sel",
+      "iso639_2en": "sel",
+      "iso639_3": "sel",
+      "name": [
+        "Selkup"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sem",
+      "iso639_2en": "sem",
+      "iso639_3": "sem",
+      "name": [
+        "Semitic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sga",
+      "iso639_2en": "sga",
+      "iso639_3": "sga",
+      "name": [
+        "Irish, Old (to 900)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sgn",
+      "iso639_2en": "sgn",
+      "iso639_3": "sgn",
+      "name": [
+        "Sign Languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "shn",
+      "iso639_2en": "shn",
+      "iso639_3": "shn",
+      "name": [
+        "Shan"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sid",
+      "iso639_2en": "sid",
+      "iso639_3": "sid",
+      "name": [
+        "Sidamo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sio",
+      "iso639_2en": "sio",
+      "iso639_3": "sio",
+      "name": [
+        "Siouan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sit",
+      "iso639_2en": "sit",
+      "iso639_3": "sit",
+      "name": [
+        "Sino-Tibetan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sla",
+      "iso639_2en": "sla",
+      "iso639_3": "sla",
+      "name": [
+        "Slavic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sma",
+      "iso639_2en": "sma",
+      "iso639_3": "sma",
+      "name": [
+        "Southern Sami"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "smi",
+      "iso639_2en": "smi",
+      "iso639_3": "smi",
+      "name": [
+        "Sami languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "smj",
+      "iso639_2en": "smj",
+      "iso639_3": "smj",
+      "name": [
+        "Lule Sami"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "smn",
+      "iso639_2en": "smn",
+      "iso639_3": "smn",
+      "name": [
+        "Inari Sami"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sms",
+      "iso639_2en": "sms",
+      "iso639_3": "sms",
+      "name": [
+        "Skolt Sami"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "snk",
+      "iso639_2en": "snk",
+      "iso639_3": "snk",
+      "name": [
+        "Soninke"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "MLI",
+        "SEN"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sog",
+      "iso639_2en": "sog",
+      "iso639_3": "sog",
+      "name": [
+        "Sogdian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "son",
+      "iso639_2en": "son",
+      "iso639_3": "son",
+      "name": [
+        "Songhai languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "srn",
+      "iso639_2en": "srn",
+      "iso639_3": "srn",
+      "name": [
+        "Sranan Tongo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "srr",
+      "iso639_2en": "srr",
+      "iso639_3": "srr",
+      "name": [
+        "Serer"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "SEN"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ssa",
+      "iso639_2en": "ssa",
+      "iso639_3": "ssa",
+      "name": [
+        "Nilo-Saharan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "suk",
+      "iso639_2en": "suk",
+      "iso639_3": "suk",
+      "name": [
+        "Sukuma"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sus",
+      "iso639_2en": "sus",
+      "iso639_3": "sus",
+      "name": [
+        "Susu"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "sux",
+      "iso639_2en": "sux",
+      "iso639_3": "sux",
+      "name": [
+        "Sumerian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "syc",
+      "iso639_2en": "syc",
+      "iso639_3": "syc",
+      "name": [
+        "Classical Syriac"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "syr",
+      "iso639_2en": "syr",
+      "iso639_3": "syr",
+      "name": [
+        "Syriac"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "langCultureMs": [
+        {
+          "langCultureName": "syr-SY",
+          "displayName": "Syriac - Syria",
+          "cultureCode": "0x045A"
+        }
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tai",
+      "iso639_2en": "tai",
+      "iso639_3": "tai",
+      "name": [
+        "Tai languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tem",
+      "iso639_2en": "tem",
+      "iso639_3": "tem",
+      "name": [
+        "Timne"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ter",
+      "iso639_2en": "ter",
+      "iso639_3": "ter",
+      "name": [
+        "Tereno"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tet",
+      "iso639_2en": "tet",
+      "iso639_3": "tet",
+      "name": [
+        "Tetum"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "TLS"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tig",
+      "iso639_2en": "tig",
+      "iso639_3": "tig",
+      "name": [
+        "Tigre"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tiv",
+      "iso639_2en": "tiv",
+      "iso639_3": "tiv",
+      "name": [
+        "Tiv"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tkl",
+      "iso639_2en": "tkl",
+      "iso639_3": "tkl",
+      "name": [
+        "Tokelau"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tlh",
+      "iso639_2en": "tlh",
+      "iso639_3": "tlh",
+      "name": [
+        "Klingon",
+        " tlhIngan-Hol"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tli",
+      "iso639_2en": "tli",
+      "iso639_3": "tli",
+      "name": [
+        "Tlingit"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tmh",
+      "iso639_2en": "tmh",
+      "iso639_3": "tmh",
+      "name": [
+        "Tamashek"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tog",
+      "iso639_2en": "tog",
+      "iso639_3": "tog",
+      "name": [
+        "Tonga (Nyasa)"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tpi",
+      "iso639_2en": "tpi",
+      "iso639_3": "tpi",
+      "name": [
+        "Tok Pisin"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "PNG"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tsi",
+      "iso639_2en": "tsi",
+      "iso639_3": "tsi",
+      "name": [
+        "Tsimshian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tum",
+      "iso639_2en": "tum",
+      "iso639_3": "tum",
+      "name": [
+        "Tumbuka"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tup",
+      "iso639_2en": "tup",
+      "iso639_3": "tup",
+      "name": [
+        "Tupi languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tut",
+      "iso639_2en": "tut",
+      "iso639_3": "tut",
+      "name": [
+        "Altaic languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tvl",
+      "iso639_2en": "tvl",
+      "iso639_3": "tvl",
+      "name": [
+        "Tuvalu"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "tyv",
+      "iso639_2en": "tyv",
+      "iso639_3": "tyv",
+      "name": [
+        "Tuvinian"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "udm",
+      "iso639_2en": "udm",
+      "iso639_3": "udm",
+      "name": [
+        "Udmurt"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "uga",
+      "iso639_2en": "uga",
+      "iso639_3": "uga",
+      "name": [
+        "Ugaritic"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "umb",
+      "iso639_2en": "umb",
+      "iso639_3": "umb",
+      "name": [
+        "Umbundu"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": "",
+      "countries": [
+        "AGO"
+      ]
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "und",
+      "iso639_2en": "und",
+      "iso639_3": "und",
+      "name": [
+        "Undetermined"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "vai",
+      "iso639_2en": "vai",
+      "iso639_3": "vai",
+      "name": [
+        "Vai"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "vot",
+      "iso639_2en": "vot",
+      "iso639_3": "vot",
+      "name": [
+        "Votic"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "wak",
+      "iso639_2en": "wak",
+      "iso639_3": "wak",
+      "name": [
+        "Wakashan languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "wal",
+      "iso639_2en": "wal",
+      "iso639_3": "wal",
+      "name": [
+        "Wolaitta",
+        " Wolaytta"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "war",
+      "iso639_2en": "war",
+      "iso639_3": "war",
+      "name": [
+        "Waray"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "was",
+      "iso639_2en": "was",
+      "iso639_3": "was",
+      "name": [
+        "Washo"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "wen",
+      "iso639_2en": "wen",
+      "iso639_3": "wen",
+      "name": [
+        "Sorbian languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "xal",
+      "iso639_2en": "xal",
+      "iso639_3": "xal",
+      "name": [
+        "Kalmyk",
+        " Oirat"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "yao",
+      "iso639_2en": "yao",
+      "iso639_3": "yao",
+      "name": [
+        "Yao"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "yap",
+      "iso639_2en": "yap",
+      "iso639_3": "yap",
+      "name": [
+        "Yapese"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "ypk",
+      "iso639_2en": "ypk",
+      "iso639_3": "ypk",
+      "name": [
+        "Yupik languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "zap",
+      "iso639_2en": "zap",
+      "iso639_3": "zap",
+      "name": [
+        "Zapotec"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "zbl",
+      "iso639_2en": "zbl",
+      "iso639_3": "zbl",
+      "name": [
+        "Blissymbols",
+        " Blissymbolics",
+        " Bliss"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "zen",
+      "iso639_2en": "zen",
+      "iso639_3": "zen",
+      "name": [
+        "Zenaga"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "zgh",
+      "iso639_2en": "zgh",
+      "iso639_3": "zgh",
+      "name": [
+        "Standard Moroccan Tamazight"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "znd",
+      "iso639_2en": "znd",
+      "iso639_3": "znd",
+      "name": [
+        "Zande languages"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "zun",
+      "iso639_2en": "zun",
+      "iso639_3": "zun",
+      "name": [
+        "Zuni"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "zxx",
+      "iso639_2en": "zxx",
+      "iso639_3": "zxx",
+      "name": [
+        "No linguistic content",
+        " Not applicable"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    },
+    {
+      "iso639_1": "",
+      "iso639_2": "zza",
+      "iso639_2en": "zza",
+      "iso639_3": "zza",
+      "name": [
+        "Zaza",
+        " Dimili",
+        " Dimli",
+        " Kirdki",
+        " Kirmanjki",
+        " Zazaki"
+      ],
+      "nativeName": [
+        ""
+      ],
+      "direction": "LTR",
+      "family": ""
+    }
+  ];
+
 function getValidLanguageOrThrow(languageCode) {
-    let language = countryLanguage.getLanguages()
+    let language = countryLanguage
         .find((a) => (a.iso639_1 && a.iso639_1 === languageCode)
             || (a.iso639_2 && a.iso639_2 === languageCode)
             || (a.iso639_3 && a.iso639_3 === languageCode));

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import validTimezones from './validTimezones';
 
+/* eslint-disable */
 export const countryLanguage = [
     {
       "iso639_1": "ab",
@@ -8384,6 +8385,7 @@ export const countryLanguage = [
     }
   ];
 
+/* eslint-enable */
 function getValidLanguageOrThrow(languageCode) {
     let language = countryLanguage
         .find((a) => (a.iso639_1 && a.iso639_1 === languageCode)


### PR DESCRIPTION
This pull request does the following:

- Changes the package name to `@cimpress-technology/customizr`
- Updates the `README` to explain how to get the latest version of the package versus previous versions
- Copies the list of language data we were using from `country-language` into the package so that we could remove the dependency on `country-language`. It's no longer maintained and had a security vulnerability. Also, we we're just importing an array of JSON data from it.